### PR TITLE
♻️ Improve candidate generation quality

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: "scripts/uv.lock"
           python-version: "3.12"
 
       - name: Install dependencies

--- a/scripts/engple/core/expression_candidates.py
+++ b/scripts/engple/core/expression_candidates.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+import random
 import re
 
 import httpx
@@ -19,6 +21,8 @@ except ImportError:  # pragma: no cover - exercised in environments without deps
 DEFAULT_WORD_POOL_SIZE = 5000
 DEFAULT_DATAMUSE_RESULTS = 32
 DEFAULT_MIN_ZIPF = 3.8
+DEFAULT_CANDIDATE_POOL_MULTIPLIER = 6
+DEFAULT_CANDIDATE_POOL_MINIMUM = 24
 DATAMUSE_TIMEOUT = 10.0
 DATAMUSE_TOPIC_SEEDS = (
     "work",
@@ -35,6 +39,44 @@ DATAMUSE_TOPIC_SEEDS = (
     "time",
 )
 EXPRESSION_RE = re.compile(r"^[a-z][a-z' -]*[a-z]$")
+NON_ENGLISH_LANGUAGE_CODES = ("es", "fr", "de", "it", "pt")
+PARTICLE_WORDS = {
+    "about",
+    "across",
+    "after",
+    "around",
+    "away",
+    "back",
+    "down",
+    "for",
+    "from",
+    "in",
+    "into",
+    "off",
+    "on",
+    "out",
+    "over",
+    "through",
+    "to",
+    "up",
+    "with",
+}
+SPELLING_VARIANT_SUFFIXES = (
+    ("isations", "izations"),
+    ("isation", "ization"),
+    ("ising", "izing"),
+    ("ised", "ized"),
+    ("ises", "izes"),
+    ("ise", "ize"),
+    ("ours", "ors"),
+    ("our", "or"),
+    ("llers", "lers"),
+    ("ller", "ler"),
+    ("lling", "ling"),
+    ("lled", "led"),
+    ("ogue", "og"),
+    ("re", "er"),
+)
 BLOCKED_SINGLE_WORDS = {
     "a",
     "about",
@@ -371,6 +413,16 @@ BLOCKED_CONTRACTIONS = {
 ENGLISH_STOP_WORDS = STOP_WORDS | BLOCKED_SINGLE_WORDS | BLOCKED_CONTRACTIONS
 
 
+@dataclass(frozen=True)
+class CandidateOption:
+    expression: str
+    score: float
+    family_key: str
+    diversity_key: str
+    is_multiword: bool
+    is_phrasal: bool
+
+
 class ExpressionCandidateCreator:
     BASE_URL = "https://api.datamuse.com"
 
@@ -381,10 +433,12 @@ class ExpressionCandidateCreator:
         word_pool_size: int = DEFAULT_WORD_POOL_SIZE,
         datamuse_results: int = DEFAULT_DATAMUSE_RESULTS,
         min_zipf: float = DEFAULT_MIN_ZIPF,
+        rng: random.Random | None = None,
     ) -> None:
         self.word_pool_size = word_pool_size
         self.datamuse_results = datamuse_results
         self.min_zipf = min_zipf
+        self._rng = rng or random.Random()
         self._owns_client = client is None
         self._client = client or httpx.AsyncClient(
             base_url=self.BASE_URL,
@@ -406,29 +460,181 @@ class ExpressionCandidateCreator:
         known_expressions = {
             normalize_expression(expression) for expression in existing_expressions
         }
-        scored_candidates: dict[str, float] = {}
-
-        for expression in self._get_wordfreq_candidates(limit=max(count * 8, count)):
-            self._add_candidate(
-                scored_candidates,
-                expression,
-                known_expressions,
-                source_bonus=0.0,
-            )
-
-        for expression in await self._get_datamuse_candidates(limit=max(count * 8, count)):
-            self._add_candidate(
-                scored_candidates,
-                expression,
-                known_expressions,
-                source_bonus=0.15,
-            )
-
-        ranked_candidates = sorted(
-            scored_candidates.items(),
-            key=lambda item: (-item[1], item[0]),
+        known_families = {
+            self._get_candidate_family_key(expression)
+            for expression in existing_expressions
+        }
+        candidates = await self._collect_candidates(
+            known_expressions,
+            known_families,
+            count,
         )
-        return [expression for expression, _ in ranked_candidates[:count]]
+        if not candidates:
+            return []
+
+        return self._select_candidates(candidates, count)
+
+    async def _collect_candidates(
+        self,
+        known_expressions: set[str],
+        known_families: set[str],
+        count: int,
+    ) -> list[CandidateOption]:
+        grouped_candidates: dict[str, CandidateOption] = {}
+
+        for limit in self._build_candidate_limits(count):
+            for expression in self._get_wordfreq_candidates(limit=limit):
+                self._add_candidate(
+                    grouped_candidates,
+                    expression,
+                    known_expressions,
+                    known_families,
+                    source_bonus=0.0,
+                )
+
+            for expression in await self._get_datamuse_candidates(limit=limit):
+                self._add_candidate(
+                    grouped_candidates,
+                    expression,
+                    known_expressions,
+                    known_families,
+                    source_bonus=0.15,
+                )
+
+            if len(grouped_candidates) >= self._get_target_pool_size(count):
+                break
+
+        return list(grouped_candidates.values())
+
+    def _select_candidates(
+        self,
+        candidates: list[CandidateOption],
+        count: int,
+    ) -> list[str]:
+        if len(candidates) <= count:
+            ranked_candidates = sorted(
+                candidates,
+                key=lambda candidate: (-candidate.score, candidate.expression),
+            )
+            return [candidate.expression for candidate in ranked_candidates]
+
+        selected: list[CandidateOption] = []
+        remaining = list(candidates)
+
+        phrasal_quota = min(
+            len([candidate for candidate in remaining if candidate.is_phrasal]),
+            max(1, count // 3),
+        )
+        selected.extend(
+            self._draw_candidates(
+                [candidate for candidate in remaining if candidate.is_phrasal],
+                phrasal_quota,
+                selected,
+            )
+        )
+        remaining = self._exclude_selected_candidates(remaining, selected)
+
+        multiword_quota = min(
+            len([candidate for candidate in remaining if candidate.is_multiword]),
+            max(0, count // 2 - len(selected)),
+        )
+        selected.extend(
+            self._draw_candidates(
+                [candidate for candidate in remaining if candidate.is_multiword],
+                multiword_quota,
+                selected,
+            )
+        )
+        remaining = self._exclude_selected_candidates(remaining, selected)
+
+        selected.extend(
+            self._draw_candidates(
+                remaining,
+                count - len(selected),
+                selected,
+            )
+        )
+
+        return [candidate.expression for candidate in selected[:count]]
+
+    def _draw_candidates(
+        self,
+        candidates: list[CandidateOption],
+        target_count: int,
+        selected: list[CandidateOption],
+    ) -> list[CandidateOption]:
+        if target_count <= 0 or not candidates:
+            return []
+
+        shortlist = self._build_selection_shortlist(candidates, target_count)
+        chosen: list[CandidateOption] = []
+        used_diversity_keys = {
+            candidate.diversity_key for candidate in selected if candidate.diversity_key
+        }
+
+        while shortlist and len(chosen) < target_count:
+            eligible = [
+                candidate
+                for candidate in shortlist
+                if candidate.diversity_key not in used_diversity_keys
+            ]
+            if not eligible:
+                eligible = shortlist
+
+            candidate = self._pick_weighted_candidate(eligible)
+            chosen.append(candidate)
+            used_diversity_keys.add(candidate.diversity_key)
+            shortlist = [
+                option
+                for option in shortlist
+                if option.family_key != candidate.family_key
+            ]
+
+        return chosen
+
+    def _build_selection_shortlist(
+        self,
+        candidates: list[CandidateOption],
+        target_count: int,
+    ) -> list[CandidateOption]:
+        shortlist_size = max(target_count * DEFAULT_CANDIDATE_POOL_MULTIPLIER, 12)
+        ranked_candidates = sorted(
+            candidates,
+            key=lambda candidate: (-candidate.score, candidate.expression),
+        )
+        return ranked_candidates[:shortlist_size]
+
+    def _pick_weighted_candidate(
+        self,
+        candidates: list[CandidateOption],
+    ) -> CandidateOption:
+        weights = [
+            max(candidate.score - self.min_zipf + 1.0, 0.1) for candidate in candidates
+        ]
+        return self._rng.choices(candidates, weights=weights, k=1)[0]
+
+    def _exclude_selected_candidates(
+        self,
+        candidates: list[CandidateOption],
+        selected: list[CandidateOption],
+    ) -> list[CandidateOption]:
+        selected_families = {candidate.family_key for candidate in selected}
+        return [
+            candidate
+            for candidate in candidates
+            if candidate.family_key not in selected_families
+        ]
+
+    def _build_candidate_limits(self, count: int) -> list[int]:
+        limits: list[int] = []
+        for multiplier in (8, 20, 40):
+            limit = max(count * multiplier, count)
+            if limit not in limits:
+                limits.append(limit)
+        return limits
+
+    def _get_target_pool_size(self, count: int) -> int:
+        return max(count * DEFAULT_CANDIDATE_POOL_MULTIPLIER, DEFAULT_CANDIDATE_POOL_MINIMUM)
 
     def _get_wordfreq_candidates(self, limit: int) -> list[str]:
         if top_n_list is None:
@@ -486,9 +692,10 @@ class ExpressionCandidateCreator:
 
     def _add_candidate(
         self,
-        scored_candidates: dict[str, float],
+        grouped_candidates: dict[str, CandidateOption],
         expression: str,
         known_expressions: set[str],
+        known_families: set[str],
         *,
         source_bonus: float,
     ) -> None:
@@ -500,9 +707,37 @@ class ExpressionCandidateCreator:
         if score <= 0:
             return
 
-        current_score = scored_candidates.get(expression)
-        if current_score is None or score > current_score:
-            scored_candidates[expression] = score
+        family_key = self._get_candidate_family_key(expression)
+        if family_key in known_families:
+            return
+
+        option = CandidateOption(
+            expression=clean_expression(expression),
+            score=score,
+            family_key=family_key,
+            diversity_key=self._get_candidate_diversity_key(expression),
+            is_multiword=" " in clean_expression(expression),
+            is_phrasal=self._is_phrasal_expression(expression),
+        )
+        current_option = grouped_candidates.get(family_key)
+        if current_option is None or self._should_replace_candidate(
+            current_option,
+            option,
+        ):
+            grouped_candidates[family_key] = option
+
+    def _should_replace_candidate(
+        self,
+        current_option: CandidateOption,
+        new_option: CandidateOption,
+    ) -> bool:
+        if new_option.score != current_option.score:
+            return new_option.score > current_option.score
+
+        if len(new_option.expression) != len(current_option.expression):
+            return len(new_option.expression) < len(current_option.expression)
+
+        return new_option.expression < current_option.expression
 
     def _score_expression(self, expression: str) -> float:
         if zipf_frequency is None:
@@ -535,7 +770,63 @@ class ExpressionCandidateCreator:
         if any(len(word) == 1 for word in words):
             return False
 
+        if any(
+            len(word) > 2 and not self._looks_like_english_word(word)
+            for word in words
+            if word not in PARTICLE_WORDS
+        ):
+            return False
+
         return True
+
+    def _looks_like_english_word(self, word: str) -> bool:
+        if zipf_frequency is None:
+            return True
+
+        english_score = float(zipf_frequency(word, "en"))
+        if english_score < self.min_zipf:
+            return False
+
+        foreign_scores = [
+            float(zipf_frequency(word, language))
+            for language in NON_ENGLISH_LANGUAGE_CODES
+        ]
+        return english_score >= max(foreign_scores, default=0.0) + 0.35
+
+    def _get_candidate_family_key(self, expression: str) -> str:
+        normalized = normalize_expression(expression)
+        tokens = normalized.split()
+        canonical_tokens = [self._canonicalize_token(token) for token in tokens]
+        return " ".join(canonical_tokens)
+
+    def _get_candidate_diversity_key(self, expression: str) -> str:
+        normalized = normalize_expression(expression)
+        tokens = normalized.split()
+        content_tokens = [
+            token for token in tokens if token not in PARTICLE_WORDS and token not in ENGLISH_STOP_WORDS
+        ]
+        seed_token = content_tokens[0] if content_tokens else tokens[0]
+        return self._canonicalize_token(seed_token)
+
+    def _canonicalize_token(self, token: str) -> str:
+        canonical_token = token.lower()
+        for source_suffix, target_suffix in SPELLING_VARIANT_SUFFIXES:
+            if (
+                canonical_token.endswith(source_suffix)
+                and len(canonical_token) > len(source_suffix) + 1
+            ):
+                canonical_token = (
+                    canonical_token[: -len(source_suffix)] + target_suffix
+                )
+                break
+        return canonical_token
+
+    def _is_phrasal_expression(self, expression: str) -> bool:
+        tokens = normalize_expression(expression).split()
+        if len(tokens) < 2:
+            return False
+
+        return any(token in PARTICLE_WORDS for token in tokens[1:])
 
 
 __all__ = ["ExpressionCandidateCreator"]

--- a/scripts/engple/core/expression_candidates.py
+++ b/scripts/engple/core/expression_candidates.py
@@ -39,28 +39,10 @@ DATAMUSE_TOPIC_SEEDS = (
     "time",
 )
 EXPRESSION_RE = re.compile(r"^[a-z][a-z' -]*[a-z]$")
+# Compare against a small set of high-signal non-English corpora so we can
+# catch obvious foreign-dominant tokens without rejecting common English
+# loanwords due to noise from every supported language in wordfreq.
 NON_ENGLISH_LANGUAGE_CODES = ("es", "fr", "de", "it", "pt")
-PARTICLE_WORDS = {
-    "about",
-    "across",
-    "after",
-    "around",
-    "away",
-    "back",
-    "down",
-    "for",
-    "from",
-    "in",
-    "into",
-    "off",
-    "on",
-    "out",
-    "over",
-    "through",
-    "to",
-    "up",
-    "with",
-}
 SPELLING_VARIANT_SUFFIXES = (
     ("isations", "izations"),
     ("isation", "ization"),
@@ -75,7 +57,6 @@ SPELLING_VARIANT_SUFFIXES = (
     ("lling", "ling"),
     ("lled", "led"),
     ("ogue", "og"),
-    ("re", "er"),
 )
 BLOCKED_SINGLE_WORDS = {
     "a",
@@ -420,7 +401,6 @@ class CandidateOption:
     family_key: str
     diversity_key: str
     is_multiword: bool
-    is_phrasal: bool
 
 
 class ExpressionCandidateCreator:
@@ -521,22 +501,9 @@ class ExpressionCandidateCreator:
         selected: list[CandidateOption] = []
         remaining = list(candidates)
 
-        phrasal_quota = min(
-            len([candidate for candidate in remaining if candidate.is_phrasal]),
-            max(1, count // 3),
-        )
-        selected.extend(
-            self._draw_candidates(
-                [candidate for candidate in remaining if candidate.is_phrasal],
-                phrasal_quota,
-                selected,
-            )
-        )
-        remaining = self._exclude_selected_candidates(remaining, selected)
-
         multiword_quota = min(
             len([candidate for candidate in remaining if candidate.is_multiword]),
-            max(0, count // 2 - len(selected)),
+            max(1, count // 2),
         )
         selected.extend(
             self._draw_candidates(
@@ -717,7 +684,6 @@ class ExpressionCandidateCreator:
             family_key=family_key,
             diversity_key=self._get_candidate_diversity_key(expression),
             is_multiword=" " in clean_expression(expression),
-            is_phrasal=self._is_phrasal_expression(expression),
         )
         current_option = grouped_candidates.get(family_key)
         if current_option is None or self._should_replace_candidate(
@@ -773,7 +739,6 @@ class ExpressionCandidateCreator:
         if any(
             len(word) > 2 and not self._looks_like_english_word(word)
             for word in words
-            if word not in PARTICLE_WORDS
         ):
             return False
 
@@ -791,7 +756,14 @@ class ExpressionCandidateCreator:
             float(zipf_frequency(word, language))
             for language in NON_ENGLISH_LANGUAGE_CODES
         ]
-        return english_score >= max(foreign_scores, default=0.0) + 0.35
+        max_foreign_score = max(foreign_scores, default=0.0)
+
+        # Keep established English loanwords and homographs unless another
+        # language is overwhelmingly more likely for this token.
+        if english_score >= self.min_zipf + 0.4:
+            return True
+
+        return max_foreign_score < english_score + 0.75
 
     def _get_candidate_family_key(self, expression: str) -> str:
         normalized = normalize_expression(expression)
@@ -803,7 +775,7 @@ class ExpressionCandidateCreator:
         normalized = normalize_expression(expression)
         tokens = normalized.split()
         content_tokens = [
-            token for token in tokens if token not in PARTICLE_WORDS and token not in ENGLISH_STOP_WORDS
+            token for token in tokens if token not in ENGLISH_STOP_WORDS
         ]
         seed_token = content_tokens[0] if content_tokens else tokens[0]
         return self._canonicalize_token(seed_token)
@@ -820,13 +792,5 @@ class ExpressionCandidateCreator:
                 )
                 break
         return canonical_token
-
-    def _is_phrasal_expression(self, expression: str) -> bool:
-        tokens = normalize_expression(expression).split()
-        if len(tokens) < 2:
-            return False
-
-        return any(token in PARTICLE_WORDS for token in tokens[1:])
-
 
 __all__ = ["ExpressionCandidateCreator"]

--- a/scripts/engple/prompts/blog.toml
+++ b/scripts/engple/prompts/blog.toml
@@ -66,20 +66,6 @@ Examples:
 {examples}
 ```"""
 
-[candidate_generation]
-prompt = """Generate everyday American English vocabulary and phrases for Korean learners.
-
-Rules:
-1. Output format: english word/phrase (한국어 뜻)
-2. Use single words, phrasal verbs, or collocations. 
-3. Strictly avoid full sentences (e.g., No "How's it going?", No "What's up?").
-4. Exclude anything in the used list.
-5. Deduplicate by English only.
-
-Used:
-{existing_expressions}
-"""
-
 [candidate_meaning]
 prompt = """Given a array of English expressions, return the same expressions with one short Korean meaning each.
 

--- a/scripts/tests/test_expression_candidates.py
+++ b/scripts/tests/test_expression_candidates.py
@@ -1,0 +1,213 @@
+"""Tests for candidate expression generation outcomes."""
+
+import asyncio
+import random
+
+from engple.core import expression_candidates as expression_candidates_module
+from engple.core.expression_candidates import ExpressionCandidateCreator
+
+
+def test_generate_groups_spelling_variants_and_keeps_multiword_candidates(
+    monkeypatch,
+):
+    """`generate` should collapse spelling variants while preserving multi-word variety."""
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "top_n_list",
+        _build_top_n_list(
+            [
+                "traveler",
+                "traveller",
+                "look after",
+                "schoolhouse",
+                "plow",
+                "outing",
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "zipf_frequency",
+        _build_zipf_frequency_lookup(
+            {
+                ("traveler", "en"): 5.3,
+                ("traveller", "en"): 5.3,
+                ("look after", "en"): 5.5,
+                ("schoolhouse", "en"): 4.9,
+                ("plow", "en"): 4.8,
+                ("outing", "en"): 4.7,
+                ("look", "en"): 5.4,
+                ("schoolhouse", "en"): 4.9,
+                ("plow", "en"): 4.8,
+                ("outing", "en"): 4.7,
+                ("figure out", "en"): 5.4,
+                ("make for", "en"): 5.0,
+                ("figure", "en"): 5.1,
+                ("make", "en"): 5.0,
+            }
+        ),
+    )
+
+    creator = ExpressionCandidateCreator(
+        client=_FakeAsyncClient(
+            {
+                "work": ["figure out", "make for", "traveller"],
+            }
+        ),
+        rng=random.Random(7),
+        word_pool_size=6,
+        datamuse_results=3,
+    )
+
+    # Given: The candidate sources contain spelling variants and several multi-word expressions.
+    existing_expressions: list[str] = []
+
+    # When: Candidate generation runs through the public API.
+    generated = asyncio.run(creator.generate(existing_expressions, 4))
+
+    # Then: Only one spelling variant should survive and at least two multi-word candidates should remain.
+    assert len(generated) == 4
+    assert len({"traveler", "traveller"} & set(generated)) <= 1
+    assert sum(" " in expression for expression in generated) >= 2
+    assert {"look after", "figure out", "make for"} & set(generated)
+
+
+def test_generate_expands_candidate_search_when_top_results_are_exhausted(
+    monkeypatch,
+):
+    """`generate` should widen the candidate window until it finds an unseen expression."""
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "top_n_list",
+        _build_top_n_list(
+            ["known expression"] * 20
+            + ["fresh phrase"]
+            + ["backup phrase", "reserve phrase"]
+        ),
+    )
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "zipf_frequency",
+        _build_zipf_frequency_lookup(
+            {
+                ("known expression", "en"): 5.1,
+                ("fresh phrase", "en"): 5.0,
+                ("backup phrase", "en"): 4.9,
+                ("reserve phrase", "en"): 4.8,
+                ("known", "en"): 5.0,
+                ("expression", "en"): 5.0,
+                ("fresh", "en"): 4.9,
+                ("phrase", "en"): 4.9,
+                ("backup", "en"): 4.8,
+                ("reserve", "en"): 4.8,
+            }
+        ),
+    )
+
+    creator = ExpressionCandidateCreator(
+        client=_FakeAsyncClient({}),
+        rng=random.Random(3),
+        word_pool_size=24,
+        datamuse_results=1,
+    )
+
+    # Given: The early candidate window is filled with already-published expressions.
+    existing_expressions = ["known expression"]
+
+    # When: Candidate generation asks for a new expression.
+    generated = asyncio.run(creator.generate(existing_expressions, 1))
+
+    # Then: The generator should widen the search enough to find a fresh candidate.
+    assert generated == ["fresh phrase"]
+
+
+def test_generate_rejects_foreign_dominant_words(
+    monkeypatch,
+):
+    """`generate` should filter out foreign-dominant words and keep clear English candidates."""
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "top_n_list",
+        _build_top_n_list(
+            [
+                "escolar",
+                "traveler",
+                "schoolhouse",
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "zipf_frequency",
+        _build_zipf_frequency_lookup(
+            {
+                ("escolar", "en"): 4.1,
+                ("escolar", "es"): 5.4,
+                ("escolar", "pt"): 4.2,
+                ("traveler", "en"): 5.0,
+                ("schoolhouse", "en"): 4.8,
+            }
+        ),
+    )
+
+    creator = ExpressionCandidateCreator(
+        client=_FakeAsyncClient({}),
+        rng=random.Random(11),
+        word_pool_size=3,
+        datamuse_results=1,
+    )
+
+    # Given: The source list mixes a Spanish-dominant token with clear English words.
+    existing_expressions: list[str] = []
+
+    # When: Candidate generation runs end-to-end.
+    generated = asyncio.run(creator.generate(existing_expressions, 2))
+
+    # Then: The foreign-dominant token should be excluded from the public result.
+    assert "escolar" not in generated
+    assert "traveler" in generated
+
+
+class _FakeAsyncClient:
+    def __init__(self, topic_results: dict[str, list[str]]) -> None:
+        self._topic_results = topic_results
+
+    async def get(self, _path: str, params: dict[str, object]) -> "_FakeResponse":
+        topic = str(params["ml"])
+        return _FakeResponse(self._topic_results.get(topic, []))
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _FakeResponse:
+    def __init__(self, words: list[str]) -> None:
+        self._words = words
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> list[dict[str, str]]:
+        return [{"word": word} for word in self._words]
+
+
+def _build_top_n_list(words: list[str]):
+    def fake_top_n_list(_language: str, _pool_size: int) -> list[str]:
+        return words
+
+    return fake_top_n_list
+
+
+def _build_zipf_frequency_lookup(
+    values: dict[tuple[str, str], float],
+):
+    def fake_zipf_frequency(word: str, language: str) -> float:
+        if (word, language) in values:
+            return values[(word, language)]
+
+        if language == "en":
+            return 4.8
+
+        return 0.0
+
+    return fake_zipf_frequency

--- a/scripts/tests/test_expression_candidates.py
+++ b/scripts/tests/test_expression_candidates.py
@@ -168,6 +168,99 @@ def test_generate_rejects_foreign_dominant_words(
     assert "traveler" in generated
 
 
+def test_generate_keeps_common_english_loanwords(
+    monkeypatch,
+):
+    """`generate` should keep common English words even when they score well in other languages too."""
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "top_n_list",
+        _build_top_n_list(
+            [
+                "menu",
+                "pizza",
+                "cafe",
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "zipf_frequency",
+        _build_zipf_frequency_lookup(
+            {
+                ("menu", "en"): 4.26,
+                ("menu", "fr"): 4.2,
+                ("pizza", "en"): 4.43,
+                ("pizza", "it"): 4.62,
+                ("cafe", "en"): 4.09,
+                ("cafe", "es"): 3.81,
+                ("cafe", "fr"): 3.18,
+            }
+        ),
+    )
+
+    creator = ExpressionCandidateCreator(
+        client=_FakeAsyncClient({}),
+        rng=random.Random(5),
+        word_pool_size=3,
+        datamuse_results=1,
+    )
+
+    # Given: The candidate source contains common English loanwords.
+    existing_expressions: list[str] = []
+
+    # When: Candidate generation runs end-to-end.
+    generated = asyncio.run(creator.generate(existing_expressions, 3))
+
+    # Then: The common English words should remain eligible.
+    assert generated == ["pizza", "menu", "cafe"]
+
+
+def test_generate_keeps_tire_distinct_from_existing_tier(
+    monkeypatch,
+):
+    """`generate` should not collapse unrelated `-re` and `-er` words into one family."""
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "top_n_list",
+        _build_top_n_list(
+            [
+                "tire",
+                "look after",
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        expression_candidates_module,
+        "zipf_frequency",
+        _build_zipf_frequency_lookup(
+            {
+                ("tire", "en"): 4.02,
+                ("tire", "fr"): 4.53,
+                ("tire", "pt"): 4.09,
+                ("look after", "en"): 5.2,
+                ("look", "en"): 5.1,
+            }
+        ),
+    )
+
+    creator = ExpressionCandidateCreator(
+        client=_FakeAsyncClient({}),
+        rng=random.Random(13),
+        word_pool_size=2,
+        datamuse_results=1,
+    )
+
+    # Given: A different word with a similar ending is already published.
+    existing_expressions = ["tier"]
+
+    # When: Candidate generation selects new expressions.
+    generated = asyncio.run(creator.generate(existing_expressions, 2))
+
+    # Then: The new word should still be considered distinct.
+    assert "tire" in generated
+
+
 class _FakeAsyncClient:
     def __init__(self, topic_results: dict[str, list[str]]) -> None:
         self._topic_results = topic_results


### PR DESCRIPTION
Why
- Candidate generation was exhausting shallow high-frequency results and often failed to find fresh expressions as the corpus grew.
- Selection quality still allowed near-duplicate spellings and foreign-dominant entries, which reduced variety in the generated list.
- The blog workflow was caching against the wrong lockfile path.

Changes
- Rework expression candidate selection to search deeper, sample more broadly, preserve multi-word expressions, and dedupe close spelling variants without collapsing unrelated words.
- Tighten candidate filtering around foreign-dominant terms while keeping common English loanwords, and cover the behavior with black-box tests.
- Remove the unused candidate-generation prompt block and fix the workflow uv cache path to `scripts/uv.lock`.

Verification
- `cd scripts && uv run pytest -q tests/test_expression_candidates.py tests/test_write_blog.py`
