### PR TITLE
✨ Add topic blog generator

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -32,11 +32,22 @@ jobs:
         run: |
           uv sync --no-dev --locked
 
-      - name: Generate blog posts
+      - name: Generate expression blog posts
         id: generate_blog
         continue-on-error: true
         run: |
-          uv run main.py write-blog --count 5
+          uv run main.py write-blog --count 4
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_ENGPLE_DATABASE_ID: ${{ secrets.NOTION_ENGPLE_DATABASE_ID }}
+          UNSPLASH_ACCESS_KEY: ${{ secrets.UNSPLASH_ACCESS_KEY }}
+
+      - name: Generate topic blog post
+        id: generate_topic_blog
+        continue-on-error: true
+        run: |
+          uv run main.py write-topic-blog
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
@@ -73,4 +84,10 @@ jobs:
         if: always() && steps.generate_blog.outcome == 'failure' && env.BLOG_CREATED != 'true'
         run: |
           echo "Blog generation failed before any publishable changes were committed."
+          exit 1
+
+      - name: Fail if any generator failed
+        if: always() && (steps.generate_blog.outcome == 'failure' || steps.generate_topic_blog.outcome == 'failure')
+        run: |
+          echo "One or more blog generators failed."
           exit 1

--- a/scripts/engple/constants.py
+++ b/scripts/engple/constants.py
@@ -5,6 +5,7 @@ ROOT_DIR = Path(__file__).parent.parent.parent
 SCRIPT_DIR = ROOT_DIR / "scripts"
 ENGPLE_DIR = SCRIPT_DIR / "engple"
 PROMPTS_PATH = ENGPLE_DIR / "prompts" / "blog.toml"
+TOPIC_PROMPTS_PATH = ENGPLE_DIR / "prompts" / "topic.toml"
 DATA_DIR = SCRIPT_DIR / "data"
 
 EXAMPLE_SENTENCES_PATH = DATA_DIR / "example_sentences.json"
@@ -13,3 +14,4 @@ BLOGMETA_EXAMPLE_PATH = DATA_DIR / "blogmeta_example.json"
 RECOMMENDATION_EXAMPLES_PATH = DATA_DIR / "recommendation_examples.json"
 
 BLOG_PROMPT = tomllib.loads(PROMPTS_PATH.read_text())
+TOPIC_PROMPT = tomllib.loads(TOPIC_PROMPTS_PATH.read_text())

--- a/scripts/engple/core/topic_blog_writer.py
+++ b/scripts/engple/core/topic_blog_writer.py
@@ -1,0 +1,218 @@
+import datetime
+from textwrap import dedent
+from typing import cast
+from zoneinfo import ZoneInfo
+
+from loguru import logger
+from pydantic import BaseModel, Field, field_validator
+from pydantic_ai import Agent
+from pydantic_ai.settings import ModelSettings
+
+from engple.config import config
+from engple.constants import TOPIC_PROMPT
+
+
+class TopicFAQ(BaseModel):
+    question: str
+    answer: str
+
+
+class TopicBlogMeta(BaseModel):
+    title: str = Field(
+        description=dedent("""\
+            Korean blog title for topic vocabulary.
+            Format: '<TOPIC> 영어로 배우기 <emoji> - <K1>, <K2>, <K3> 영어로'
+            If this is a follow-up post for the same topic, include '#<NUMBER>'.
+            Example: '동물 영어로 배우기 🐾 - 개, 고양이, 토끼 영어로'
+            Example: '가전제품 영어로 배우기 #1 📺 - 에어컨, 세탁기, 냉장고 영어로'
+            """),
+    )
+    alt: str = Field(
+        description="Korean alt text for the blog thumbnail image.",
+    )
+    description: str = Field(
+        description=dedent("""\
+            Korean SEO description around 100-160 characters.
+            Mention 3-5 Korean vocabulary items from the content and practical examples.
+            Example: "'개', '고양이', '토끼'를 영어로 어떻게 표현하면 좋을까요? '개를 산책시키다', '고양이에게 밥을 주다' 등을 영어로 표현하는 법을 배워봅시다."
+            """),
+    )
+    faqs: list[TopicFAQ] = Field(
+        description="4-5 Korean FAQ pairs based on vocabulary from the content.",
+    )
+
+
+class TopicBlogContent(BaseModel):
+    vocabs: list[str] = Field(
+        description=dedent("""\
+            English vocabulary items included in the post.
+            Use 5-8 items.
+            Items must belong to the same hierarchy level.
+            """),
+    )
+    content: str = Field(
+        description="Markdown body for the topic vocabulary post in Korean.",
+    )
+
+    @field_validator("content")
+    def validate_content(cls, value: str) -> str:
+        return value.replace("\\n", "\n").strip()
+
+
+class GeneratedTopicBlog(BaseModel):
+    topic: str
+    vocabs: list[str]
+    content: str
+
+
+class TopicBlogWriter:
+    def __init__(self):
+        self.model_content = config.model_content
+        self.model_meta = config.model_meta
+
+    async def generate(
+        self,
+        topic: str,
+        blog_num: int,
+        posted_at: datetime.datetime | None = None,
+        excludes: list[str] | None = None,
+        topic_sequence: int = 1,
+        include_thumbnail: bool = True,
+    ) -> GeneratedTopicBlog:
+        """Write a topic vocabulary blog for the given topic."""
+        topic_content = await self._write_topic_content(topic, excludes or [])
+        topic_meta = await self._write_topic_meta(topic, topic_content, topic_sequence)
+        final_content = self._get_final_content(
+            topic_content,
+            topic_meta,
+            blog_num,
+            posted_at,
+            include_thumbnail,
+        )
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=topic_content.vocabs,
+            content=final_content,
+        )
+
+    async def _write_topic_content(
+        self, topic: str, excludes: list[str]
+    ) -> TopicBlogContent:
+        """Write the topic vocabulary blog body."""
+        logger.info("✍️ 주제별 영어 블로그 작성 중...")
+        content_agent = Agent(
+            self.model_content,
+            output_type=TopicBlogContent,
+            system_prompt=self._build_topic_prompt(excludes),
+            retries=2,
+            model_settings=ModelSettings(temperature=0.7),
+        )
+        result = await content_agent.run(f"topic: '{topic}'")
+        return cast(TopicBlogContent, result.output)
+
+    def _build_topic_prompt(self, excludes: list[str]) -> str:
+        prompt = TOPIC_PROMPT["prompt"].format(
+            example=TOPIC_PROMPT["content"]["example"]
+        )
+        if excludes:
+            prompt += "\n\n" + TOPIC_PROMPT["exclude_prompt"].format(
+                excludes=", ".join(excludes)
+            )
+        return prompt
+
+    async def _write_topic_meta(
+        self, topic: str, content: TopicBlogContent, topic_sequence: int
+    ) -> TopicBlogMeta:
+        """Write metadata for the topic vocabulary blog."""
+        logger.info("📝 주제별 영어 메타 설명 작성 중...")
+        meta_agent = Agent(
+            self.model_meta,
+            output_type=TopicBlogMeta,
+            system_prompt=TOPIC_PROMPT["meta_prompt"],
+            retries=2,
+            model_settings=ModelSettings(temperature=0.3),
+        )
+        result = await meta_agent.run(
+            f"topic: {topic}\nseries_number: {topic_sequence}\n\n{content.content}"
+        )
+        return cast(TopicBlogMeta, result.output)
+
+    def _get_final_content(
+        self,
+        content: TopicBlogContent,
+        meta: TopicBlogMeta,
+        blog_num: int,
+        posted_at: datetime.datetime | None,
+        include_thumbnail: bool,
+    ) -> str:
+        """Get the final markdown content for a topic post."""
+        logger.info("💾 주제별 영어 블로그 출력 저장 중...")
+        post_date = self._get_post_date(posted_at)
+        faqs_section = self._format_faqs(meta.faqs)
+        thumbnail_frontmatter = self._format_thumbnail_frontmatter(
+            meta,
+            blog_num,
+            include_thumbnail,
+        )
+        thumbnail_body = self._format_thumbnail_body(meta, blog_num, include_thumbnail)
+        return (
+            "---\n"
+            f'title: "{self._escape_text(meta.title)}"\n'
+            'category: "주제별영어"\n'
+            f'date: "{post_date}"\n'
+            f"{thumbnail_frontmatter}"
+            f'desc: "{self._format_description(meta.description)}"\n'
+            "faqs:\n"
+            f"{faqs_section}"
+            "---\n\n"
+            f"{thumbnail_body}"
+            f"{content.content}\n"
+        )
+
+    def _format_thumbnail_frontmatter(
+        self, meta: TopicBlogMeta, blog_num: int, include_thumbnail: bool
+    ) -> str:
+        if not include_thumbnail:
+            return ""
+        return (
+            f'thumbnail: "./{blog_num:03d}.png"\n'
+            f'alt: "{self._escape_text(meta.alt)}"\n'
+        )
+
+    def _format_thumbnail_body(
+        self, meta: TopicBlogMeta, blog_num: int, include_thumbnail: bool
+    ) -> str:
+        if not include_thumbnail:
+            return ""
+        return f"![{self._escape_text(meta.alt)}](./{blog_num:03d}.png)\n\n"
+
+    def _get_post_date(self, posted_at: datetime.datetime | None) -> str:
+        date = posted_at or datetime.datetime.now(tz=ZoneInfo("Asia/Seoul"))
+        if date.tzinfo is None:
+            date = date.replace(tzinfo=ZoneInfo("Asia/Seoul"))
+        return date.isoformat(timespec="minutes")
+
+    def _format_description(self, description: str) -> str:
+        escaped_description = self._escape_text(description)
+        return (
+            f"{escaped_description} 다양한 예문을 통해서 연습하고 "
+            "본인의 표현으로 만들어 보세요."
+        )
+
+    def _format_faqs(self, faqs: list[TopicFAQ]) -> str:
+        faqs_section = ""
+        for faq in faqs:
+            faqs_section += f'  - question: "{self._escape_text(faq.question)}"\n'
+            faqs_section += f'    answer: "{self._escape_text(faq.answer)}"\n'
+        return faqs_section
+
+    def _escape_text(self, text: str) -> str:
+        return text.replace('"', "'").replace("‘", "'").replace("’", "'")
+
+
+__all__ = [
+    "GeneratedTopicBlog",
+    "TopicBlogContent",
+    "TopicBlogMeta",
+    "TopicBlogWriter",
+]

--- a/scripts/engple/prompts/topic.toml
+++ b/scripts/engple/prompts/topic.toml
@@ -1,0 +1,239 @@
+prompt = """Write a Korean blog post that teaches English vocabulary for the given <TOPIC>.
+
+Rules:
+- The post is for Korean speakers learning practical English vocabulary.
+- Choose vocabulary items that belong to the same hierarchy level.
+- For a topic like "동물", use direct animal names such as "개", "고양이", "토끼", "소", "치타".
+- For a topic like "가구", use direct furniture names such as "소파", "의자", "테이블", "책상", "침대".
+- Do not mix parent/child levels in the same post.
+- Explain each English word in Korean.
+- Include two natural American English example sentences and Korean translations for each word.
+- Write Korean translations in the friendly "~해요" style.
+- Use <span data-pronunciation="word"> for pronunciation.
+- Prefer natural Korean terms that people actually use in daily life.
+- Prefer native Korean terms over loanwords when both are natural.
+- Do not use two or more emojis in a row.
+- Follow the structure and line spacing of the example.
+
+## Example:
+
+```
+{example}
+```
+"""
+
+exclude_prompt = """Avoid these vocabulary items because they were already used for this topic:
+{excludes}
+"""
+
+meta_prompt = """Write Korean metadata for a topic English vocabulary blog post.
+
+Rules:
+- Base the metadata only on the given content.
+- Follow the examples in each field description.
+- If series_number is greater than 1, include '#<series_number>' in the title.
+- Write 4 or 5 FAQ pairs.
+- FAQ questions should ask how to say Korean vocabulary from the content in English.
+- FAQ answers should include the English word and a practical usage example.
+- Use the friendly "~해요" style.
+"""
+
+topic_pool = [
+  "가구",
+  "가전제품",
+  "가족 관계",
+  "감정",
+  "강아지 용품",
+  "건물",
+  "건강검진",
+  "겨울 옷",
+  "결혼식",
+  "공구",
+  "공항",
+  "교통수단",
+  "교통 표지판",
+  "금융",
+  "꽃",
+  "낚시",
+  "날씨",
+  "냉장고 음식",
+  "농장 동물",
+  "동물",
+  "디저트",
+  "미용실",
+  "바다 생물",
+  "반려동물",
+  "방향",
+  "배달 음식",
+  "버스",
+  "부동산",
+  "사무실",
+  "문구류",
+  "병원",
+  "보드게임",
+  "봄 옷",
+  "사진 촬영",
+  "사무용품",
+  "산",
+  "생일파티",
+  "세탁",
+  "수영",
+  "수족관",
+  "색깔",
+  "스마트폰",
+  "쇼핑",
+  "식기",
+  "식당",
+  "신발",
+  "악기",
+  "약국",
+  "어린이 장난감",
+  "여름 옷",
+  "여행준비물",
+  "영화관",
+  "옷감",
+  "운동",
+  "운동 기구",
+  "운전",
+  "은행",
+  "음료",
+  "음식 맛",
+  "의류",
+  "인체",
+  "자동차",
+  "자동차 부품",
+  "자연재해",
+  "잠",
+  "전자기기",
+  "정원",
+  "주방",
+  "주방가전",
+  "조리도구",
+  "청소",
+  "카페",
+  "캠핑",
+  "컴퓨터",
+  "직업",
+  "채소",
+  "책",
+  "초등학교",
+  "치과",
+  "취미",
+  "컴퓨터 용품",
+  "택배",
+  "패스트푸드",
+  "피부관리",
+  "해변",
+  "헬스장",
+  "호텔",
+  "화장품",
+  "회사 직책",
+  "회의",
+  "가방",
+  "간식",
+  "감기 증상",
+  "거리 시설",
+  "건강식품",
+  "게임",
+  "계절",
+  "과일",
+  "교실",
+  "국가",
+  "날짜",
+  "도서관",
+  "동작",
+  "마트",
+  "명절",
+  "문",
+  "미술 도구",
+  "방",
+  "방송",
+  "법원",
+  "보석",
+  "비즈니스 문서",
+  "소셜미디어",
+  "숫자",
+  "시간",
+  "악천후",
+  "앱",
+  "아파트",
+  "요가",
+  "우체국",
+  "위치",
+  "음악 장르",
+  "의학 용어",
+  "인터넷",
+  "재료",
+  "지하철",
+  "카메라",
+  "캠핑 장비",
+  "컴퓨터 부품",
+  "패션 소품",
+  "학교 과목",
+  "항공",
+  "해산물",
+  "환경",
+  "회사 부서",
+]
+
+[content]
+example = """주방에서 요리를 할 때 가장 많이 사용하는 도구들을 영어로는 어떻게 표현할까요? 오늘은 칼(knife), 냄비(pot), 프라이팬(frying pan) 등 기본적인 조리도구들의 영어 표현을 알아볼게요. 각 도구의 발음과 함께 관련 표현, 예문들도 함께 살펴볼 거예요. 이 표현들을 익히고 나면 요리 관련 영어 대화나 레시피를 이해하는 데 큰 도움이 될 거예요.
+
+## 1. 칼 (Knife)
+
+음식을 자르고 썰기 위해 사용하는 가장 기본적인 주방 도구예요.
+
+### 🗣️ 발음
+
+- <span data-pronunciation="knife">발음기호: /naɪf/</span>
+- 한국어 발음: 나이프
+
+### 💭 관련 표현
+
+- sharp knife: 날카로운 칼
+- kitchen knife: 주방용 칼
+- butter knife: 버터 나이프
+
+### 📝 예문으로 연습하기!
+
+1. "Always be careful when using a sharp knife."
+
+   "날카로운 칼을 사용할 때는 항상 조심해야 해요."
+
+2. "I need a knife to chop these vegetables."
+
+   "야채를 썰려면 칼이 필요해요."
+
+## 2. 냄비 (Pot)
+
+음식을 끓이거나 조리하는 데 사용하는 깊이가 있는 조리 용기예요.
+
+### 🗣️ 발음
+
+- <span data-pronunciation="pot">발음기호: /pɑːt/</span>
+- 한국어 발음: 팟
+
+### 💭 관련 표현
+
+- cooking pot: 요리 냄비
+- soup pot: 수프 냄비
+- stainless steel pot: 스테인리스 냄비
+
+### 📝 예문으로 연습하기!
+
+1. "I boiled water in the pot for pasta."
+
+   "파스타를 위해 냄비에 물을 끓였어요."
+
+2. "This pot is perfect for making stew."
+
+   "이 냄비는 스튜 만들기에 딱이에요."
+
+---
+
+이렇게 조리도구와 관련된 영어 단어와 예문을 알아봤어요!
+
+오늘 배운 단어와 예문들을 최소 3번 소리내어 말해보세요. 반복해서 소리내어 말하는 것만큼 영어 학습에 도움되는 것은 없어요!
+
+그럼 다음에 더 유용한 단어와 예문들로 찾아올게요~
+"""

--- a/scripts/engple/services/write_topic_blog.py
+++ b/scripts/engple/services/write_topic_blog.py
@@ -1,0 +1,190 @@
+import datetime
+import random
+import re
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from loguru import logger
+
+from engple.config import config
+from engple.constants import TOPIC_PROMPT
+from engple.core.image_searcher import search_image
+from engple.core.topic_blog_writer import GeneratedTopicBlog, TopicBlogWriter
+from engple.utils import render_topic_thumbnail
+
+TOPIC_HEADING_RE = re.compile(
+    r"^##\s+\d+\.\s+(.+?)\s*\((.+?)\)\s*$",
+    re.MULTILINE,
+)
+TITLE_RE = re.compile(r'^title:\s*["\']?(.+?)["\']?\s*$', re.MULTILINE)
+TOPIC_TITLE_RE = re.compile(r"^(.+?)\s+영어(?:로)?\s+(?:표현하기|배우기|단어 배우기)")
+
+
+async def handle_write_topic_blog(
+    topic: str | None = None,
+    *,
+    excludes: list[str] | None = None,
+    with_thumbnail: bool = True,
+) -> Path:
+    writer = TopicBlogWriter()
+    selected_topic = _select_topic(topic)
+    blog_num = _get_next_topic_blog_num()
+    posted_at = datetime.datetime.now(tz=ZoneInfo("Asia/Seoul"))
+    topic_excludes = _build_topic_excludes(excludes or [])
+    topic_sequence = _get_next_topic_sequence(selected_topic)
+    generated_blog = await writer.generate(
+        selected_topic,
+        blog_num,
+        posted_at,
+        topic_excludes,
+        topic_sequence,
+        with_thumbnail,
+    )
+    _reject_duplicate_vocabs(generated_blog, topic_excludes)
+
+    blog_path = _get_topic_post_path(blog_num)
+
+    if with_thumbnail:
+        thumbnail_path = blog_path.with_suffix(".png")
+        await generate_topic_thumbnail(thumbnail_path, selected_topic)
+
+    _write_topic_post(generated_blog, blog_path)
+
+    logger.debug(f"✅ Successfully wrote topic blog for {selected_topic}")
+    return blog_path
+
+
+def _select_topic(topic: str | None) -> str:
+    if topic:
+        return topic
+
+    topic_pool = [item.strip() for item in TOPIC_PROMPT["topic_pool"] if item.strip()]
+    if not topic_pool:
+        raise RuntimeError("Topic pool is empty.")
+
+    return random.choice(topic_pool)
+
+
+def _get_next_topic_blog_num() -> int:
+    topic_dir = config.blog_dir / "topic"
+    existing_numbers = [
+        int(path.stem.split(".")[0])
+        for path in sorted(topic_dir.rglob("*.md"))
+        if path.stem.split(".")[0].isdigit()
+    ]
+    if not existing_numbers:
+        return 1
+    return max(existing_numbers) + 1
+
+
+def _build_topic_excludes(requested_excludes: list[str]) -> list[str]:
+    existing_excludes = _get_existing_topic_vocabs()
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for item in [*existing_excludes, *requested_excludes]:
+        key = item.strip().lower()
+        if not key or key in seen:
+            continue
+        deduped.append(item.strip())
+        seen.add(key)
+    return deduped
+
+
+def _reject_duplicate_vocabs(
+    generated_blog: GeneratedTopicBlog, topic_excludes: list[str]
+) -> None:
+    excluded = {_normalize_vocab(item) for item in topic_excludes}
+    generated = {
+        _normalize_vocab(item)
+        for item in [
+            *generated_blog.vocabs,
+            *_extract_topic_heading_vocabs(generated_blog.content),
+        ]
+    }
+    duplicates = sorted(item for item in generated if item in excluded)
+    if duplicates:
+        raise RuntimeError(
+            "Generated topic blog reused excluded vocabulary: "
+            f"{', '.join(duplicates)}"
+        )
+
+
+def _extract_topic_heading_vocabs(content: str) -> list[str]:
+    vocabs: list[str] = []
+    for korean, english in TOPIC_HEADING_RE.findall(content):
+        vocabs.extend([korean.strip(), english.strip()])
+    return vocabs
+
+
+def _normalize_vocab(vocab: str) -> str:
+    return vocab.strip().lower()
+
+
+def _get_next_topic_sequence(topic: str) -> int:
+    topic_dir = config.blog_dir / "topic"
+    if not topic_dir.exists():
+        return 1
+
+    post_count = 0
+    for path in sorted(topic_dir.rglob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        title = _extract_title(content)
+        if _is_topic_title_match(title, topic):
+            post_count += 1
+    return post_count + 1
+
+
+def _is_topic_title_match(title: str, topic: str) -> bool:
+    return _normalize_topic(_extract_topic_from_title(title)) == _normalize_topic(topic)
+
+
+def _extract_topic_from_title(title: str) -> str:
+    match = TOPIC_TITLE_RE.search(title)
+    if not match:
+        return ""
+    return re.sub(r"\s+#\d+\s*$", "", match.group(1)).strip()
+
+
+def _normalize_topic(topic: str) -> str:
+    return re.sub(r"\s+", "", topic.strip().lower())
+
+
+def _get_existing_topic_vocabs() -> list[str]:
+    topic_dir = config.blog_dir / "topic"
+    if not topic_dir.exists():
+        return []
+
+    vocabs: list[str] = []
+    for path in sorted(topic_dir.rglob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        vocabs.extend(_extract_topic_heading_vocabs(content))
+    return vocabs
+
+
+def _extract_title(content: str) -> str:
+    match = TITLE_RE.search(content)
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
+def _get_topic_post_path(blog_num: int) -> Path:
+    topic_dir = config.blog_dir / "topic"
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    return topic_dir / f"{blog_num:03d}.md"
+
+
+def _write_topic_post(generated_blog: GeneratedTopicBlog, blog_path: Path) -> None:
+    blog_path.write_text(generated_blog.content, encoding="utf-8")
+
+
+async def generate_topic_thumbnail(path: Path, topic: str) -> None:
+    image = await search_image(f"{topic} English vocabulary")
+    render_topic_thumbnail(path.as_posix(), image.url, topic)
+    logger.debug(f"✅ Successfully generated topic thumbnail for {topic}")
+
+
+__all__ = [
+    "generate_topic_thumbnail",
+    "handle_write_topic_blog",
+]

--- a/scripts/engple/utils/__init__.py
+++ b/scripts/engple/utils/__init__.py
@@ -6,7 +6,7 @@ from .expr_path import (
     get_expr_path,
     normalize_expression,
 )
-from .image import url_to_file
+from .image import render_topic_thumbnail, url_to_file
 
 __all__ = [
     "clean_expression",
@@ -15,5 +15,6 @@ __all__ = [
     "get_existing_expression_map",
     "get_expr_path",
     "normalize_expression",
+    "render_topic_thumbnail",
     "url_to_file",
 ]

--- a/scripts/engple/utils/image.py
+++ b/scripts/engple/utils/image.py
@@ -74,3 +74,46 @@ def render_expression_thumbnail(path: str, image_url: str, ko: str) -> None:
         .outline(width=16, color="#1FFFAA")
     )
     canvas.render(path)
+
+
+def render_topic_thumbnail(path: str, image_url: str, topic: str) -> None:
+    """
+    Render a topic vocabulary thumbnail image from a topic name.
+
+    Args:
+        path: The path to save the thumbnail
+        image_url: The URL of the image
+        topic: The Korean topic name
+    """
+    font_dir = os.path.join(os.path.dirname(__file__), "../assets/fonts")
+    canvas = (
+        Canvas.from_aspect_ratio("16:9", 1280)
+        .background(image=image_url, fit=FitMode.COVER)
+        .background(color="#000000", opacity=0.66)
+        .text(
+            content=[
+                TextPart(
+                    text=f"{topic}\n",
+                    color="#FFBF1F",
+                    size=120,
+                    font=os.path.join(font_dir, "JalnanGothic.otf"),
+                    effects=[Stroke(width=8, color="#000000")],
+                ),
+                TextPart(
+                    text=" \n",
+                    size=28,
+                ),
+                TextPart(
+                    text="영어로 어떻게 표현할까?",
+                    color="#FFFFFF",
+                    size=56,
+                    font=os.path.join(font_dir, "SpoqaHanSansNeo-Medium.otf"),
+                ),
+            ],
+            position=("50%", "50%"),
+            align=("center", "middle"),
+            bold=True,
+        )
+        .outline(width=16, color="#FFBF1F")
+    )
+    canvas.render(path)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -5,6 +5,7 @@ from loguru import logger
 import typer
 
 from engple.services.write_blog import handle_write_blog
+from engple.services.write_topic_blog import handle_write_topic_blog
 from engple.services.link_expression import handle_link_expression
 from engple.services.link_all_expressions import handle_link_all_expressions
 
@@ -98,6 +99,36 @@ def write_blog(
                     continue
 
     asyncio.run(_write_blog())
+
+
+@app.command()
+def write_topic_blog(
+    topic: str | None = typer.Argument(
+        None,
+        help="The Korean topic to generate. Omit to auto-select a new topic.",
+    ),
+    exclude: list[str] = typer.Option(
+        [],
+        "--exclude",
+        help="Vocabulary item to avoid. Repeat this option for multiple items.",
+    ),
+    no_thumbnail: bool = typer.Option(
+        False,
+        "--no-thumbnail",
+        help="Do not generate a thumbnail image",
+    ),
+) -> None:
+    """Generate a topic vocabulary blog post."""
+
+    async def _write_topic_blog():
+        blog_path = await handle_write_topic_blog(
+            topic,
+            excludes=exclude,
+            with_thumbnail=not no_thumbnail,
+        )
+        logger.info(f"Generated topic blog: {blog_path}\n")
+
+    asyncio.run(_write_topic_blog())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_write_topic_blog.py
+++ b/scripts/tests/test_write_topic_blog.py
@@ -1,0 +1,481 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from engple.config import config
+from engple.constants import TOPIC_PROMPT
+from engple.core.topic_blog_writer import (
+    GeneratedTopicBlog,
+    TopicBlogContent,
+    TopicBlogMeta,
+    TopicBlogWriter,
+    TopicFAQ,
+)
+from engple.services import write_topic_blog as write_topic_blog_service
+
+
+@pytest.fixture
+def temp_topic_blog_dir(tmp_path, monkeypatch):
+    """Provide a temporary blog directory with existing topic posts."""
+    blog_dir = tmp_path / "blog"
+    topic_dir = blog_dir / "topic"
+    topic_dir.mkdir(parents=True)
+    (topic_dir / "001.md").write_text(
+        (
+            "---\n"
+            'title: "동물 영어로 배우기 - 개, 고양이 영어로"\n'
+            'category: "주제별영어"\n'
+            "---\n\n"
+            "## 1. 개 (Dog)\n\n"
+            "## 2. 고양이(Cat)\n"
+        ),
+        encoding="utf-8",
+    )
+    (topic_dir / "002.md").write_text(
+        (
+            "---\n"
+            'title: "가구 영어로 배우기 - 의자 영어로"\n'
+            'category: "주제별영어"\n'
+            "---\n\n"
+            "## 1. 의자 (Chair)\n"
+        ),
+        encoding="utf-8",
+    )
+    (topic_dir / "003.md").write_text(
+        (
+            "---\n"
+            'title: "가전제품 영어로 배우기 #2 ⚡ - 다리미 영어로"\n'
+            'category: "주제별영어"\n'
+            "---\n\n"
+            "## 1. 다리미 (Iron)\n"
+        ),
+        encoding="utf-8",
+    )
+    (topic_dir / "004.md").write_text(
+        (
+            "---\n"
+            'title: "운동 기구 영어로 배우기 #1 💪 - 덤벨 영어로"\n'
+            'category: "주제별영어"\n'
+            "---\n\n"
+            "## 1. 덤벨 (Dumbbell)\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "blog_dir", blog_dir)
+    return topic_dir
+
+
+def test_handle_write_topic_blog_writes_next_topic_post_with_excludes(
+    temp_topic_blog_dir,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should write the next topic post with deduped excludes."""
+    captured: dict[str, object] = {}
+
+    async def generate(
+        self,
+        topic,
+        blog_num,
+        posted_at,
+        excludes,
+        topic_sequence,
+        include_thumbnail,
+    ):
+        captured["topic"] = topic
+        captured["blog_num"] = blog_num
+        captured["excludes"] = excludes
+        captured["topic_sequence"] = topic_sequence
+        captured["include_thumbnail"] = include_thumbnail
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=["rabbit"],
+            content="---\ncategory: \"주제별영어\"\n---\n\nGenerated body.\n",
+        )
+
+    async def fail_thumbnail(*args, **kwargs):
+        raise AssertionError("thumbnail generation should be disabled")
+
+    monkeypatch.setattr(TopicBlogWriter, "generate", generate)
+    monkeypatch.setattr(
+        write_topic_blog_service,
+        "generate_topic_thumbnail",
+        fail_thumbnail,
+    )
+
+    # Given
+    topic = "동물"
+    excludes = ["Cat", "소"]
+
+    # When
+    result = asyncio.run(
+        write_topic_blog_service.handle_write_topic_blog(
+            topic,
+            excludes=excludes,
+            with_thumbnail=False,
+        )
+    )
+
+    # Then
+    assert result == temp_topic_blog_dir / "005.md"
+    assert result.read_text(encoding="utf-8").endswith("Generated body.\n")
+    assert captured["topic"] == "동물"
+    assert captured["blog_num"] == 5
+    assert captured["excludes"] == [
+        "개",
+        "Dog",
+        "고양이",
+        "Cat",
+        "의자",
+        "Chair",
+        "다리미",
+        "Iron",
+        "덤벨",
+        "Dumbbell",
+        "소",
+    ]
+    assert captured["topic_sequence"] == 2
+    assert captured["include_thumbnail"] is False
+
+
+def test_handle_write_topic_blog_generates_thumbnail_by_default(
+    temp_topic_blog_dir,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should generate a matching PNG thumbnail by default."""
+    captured_thumbnail: dict[str, object] = {}
+
+    async def generate(
+        self,
+        topic,
+        blog_num,
+        posted_at,
+        excludes,
+        topic_sequence,
+        include_thumbnail,
+    ):
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=["rabbit"],
+            content="---\ncategory: \"주제별영어\"\n---\n\nGenerated body.\n",
+        )
+
+    async def generate_thumbnail(path: Path, topic: str):
+        captured_thumbnail["path"] = path
+        captured_thumbnail["topic"] = topic
+
+    monkeypatch.setattr(TopicBlogWriter, "generate", generate)
+    monkeypatch.setattr(
+        write_topic_blog_service,
+        "generate_topic_thumbnail",
+        generate_thumbnail,
+    )
+
+    # Given
+    topic = "동물"
+
+    # When
+    result = asyncio.run(write_topic_blog_service.handle_write_topic_blog(topic))
+
+    # Then
+    assert result == temp_topic_blog_dir / "005.md"
+    assert captured_thumbnail == {
+        "path": temp_topic_blog_dir / "005.png",
+        "topic": "동물",
+    }
+
+
+def test_handle_write_topic_blog_does_not_write_post_when_thumbnail_fails(
+    temp_topic_blog_dir,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should leave no markdown post when thumbnail generation fails."""
+
+    async def generate(
+        self,
+        topic,
+        blog_num,
+        posted_at,
+        excludes,
+        topic_sequence,
+        include_thumbnail,
+    ):
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=["rabbit"],
+            content="---\ncategory: \"주제별영어\"\n---\n\nGenerated body.\n",
+        )
+
+    async def fail_thumbnail(path: Path, topic: str):
+        raise RuntimeError("thumbnail failed")
+
+    monkeypatch.setattr(TopicBlogWriter, "generate", generate)
+    monkeypatch.setattr(
+        write_topic_blog_service,
+        "generate_topic_thumbnail",
+        fail_thumbnail,
+    )
+
+    # Given
+    topic = "동물"
+
+    # When / Then
+    with pytest.raises(RuntimeError, match="thumbnail failed"):
+        asyncio.run(write_topic_blog_service.handle_write_topic_blog(topic))
+
+    assert not (temp_topic_blog_dir / "005.md").exists()
+
+
+def test_handle_write_topic_blog_rejects_generated_duplicate_vocabulary(
+    temp_topic_blog_dir,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should reject output that reuses excluded vocabulary."""
+
+    async def generate(
+        self,
+        topic,
+        blog_num,
+        posted_at,
+        excludes,
+        topic_sequence,
+        include_thumbnail,
+    ):
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=["rabbit"],
+            content=(
+                "---\ncategory: \"주제별영어\"\n---\n\n"
+                "## 1. 토끼 (Rabbit)\n\n"
+                "## 2. 개 (Dog)\n"
+            ),
+        )
+
+    async def fail_thumbnail(*args, **kwargs):
+        raise AssertionError("thumbnail generation should not run for duplicates")
+
+    monkeypatch.setattr(TopicBlogWriter, "generate", generate)
+    monkeypatch.setattr(
+        write_topic_blog_service,
+        "generate_topic_thumbnail",
+        fail_thumbnail,
+    )
+
+    # Given
+    topic = "동물"
+
+    # When / Then
+    with pytest.raises(RuntimeError, match="dog"):
+        asyncio.run(write_topic_blog_service.handle_write_topic_blog(topic))
+
+    assert not (temp_topic_blog_dir / "005.md").exists()
+
+
+def test_handle_write_topic_blog_auto_selects_new_topic(
+    temp_topic_blog_dir,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should select a topic from the configured pool."""
+    captured: dict[str, object] = {}
+
+    async def generate(
+        self,
+        topic,
+        blog_num,
+        posted_at,
+        excludes,
+        topic_sequence,
+        include_thumbnail,
+    ):
+        captured["topic"] = topic
+        captured["excludes"] = excludes
+        captured["topic_sequence"] = topic_sequence
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=["rabbit"],
+            content="---\ncategory: \"주제별영어\"\n---\n\nGenerated body.\n",
+        )
+
+    async def generate_thumbnail(path: Path, topic: str):
+        captured["thumbnail_topic"] = topic
+
+    monkeypatch.setattr(write_topic_blog_service.random, "choice", lambda _: "동물")
+    monkeypatch.setattr(TopicBlogWriter, "generate", generate)
+    monkeypatch.setattr(
+        write_topic_blog_service,
+        "generate_topic_thumbnail",
+        generate_thumbnail,
+    )
+
+    # Given
+    topic = None
+
+    # When
+    result = asyncio.run(write_topic_blog_service.handle_write_topic_blog(topic))
+
+    # Then
+    assert result == temp_topic_blog_dir / "005.md"
+    assert captured["topic"] == "동물"
+    assert captured["excludes"] == [
+        "개",
+        "Dog",
+        "고양이",
+        "Cat",
+        "의자",
+        "Chair",
+        "다리미",
+        "Iron",
+        "덤벨",
+        "Dumbbell",
+    ]
+    assert captured["topic_sequence"] == 2
+    assert captured["thumbnail_topic"] == "동물"
+
+
+def test_handle_write_topic_blog_raises_when_topic_pool_is_empty(
+    tmp_path,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should fail when no automatic topics are configured."""
+    blog_dir = tmp_path / "blog"
+    monkeypatch.setattr(config, "blog_dir", blog_dir)
+    monkeypatch.setitem(write_topic_blog_service.TOPIC_PROMPT, "topic_pool", [])
+
+    async def fail_generate(*args, **kwargs):
+        raise AssertionError("generate should not run without a topic")
+
+    monkeypatch.setattr(TopicBlogWriter, "generate", fail_generate)
+
+    # Given
+    topic = None
+
+    # When / Then
+    with pytest.raises(RuntimeError, match="Topic pool is empty"):
+        asyncio.run(
+            write_topic_blog_service.handle_write_topic_blog(
+                topic,
+                with_thumbnail=False,
+            )
+        )
+
+
+def test_handle_write_topic_blog_matches_existing_vocab_by_exact_topic(
+    temp_topic_blog_dir,
+    monkeypatch,
+):
+    """`handle_write_topic_blog` should not mix overlapping topic vocabularies."""
+    captured: dict[str, object] = {}
+
+    async def generate(
+        self,
+        topic,
+        blog_num,
+        posted_at,
+        excludes,
+        topic_sequence,
+        include_thumbnail,
+    ):
+        captured["topic"] = topic
+        captured["excludes"] = excludes
+        captured["topic_sequence"] = topic_sequence
+        return GeneratedTopicBlog(
+            topic=topic,
+            vocabs=["stretching"],
+            content="---\ncategory: \"주제별영어\"\n---\n\nGenerated body.\n",
+        )
+
+    monkeypatch.setattr(write_topic_blog_service.random, "choice", lambda _: "운동")
+    monkeypatch.setattr(TopicBlogWriter, "generate", generate)
+
+    # Given
+    topic = None
+
+    # When
+    result = asyncio.run(
+        write_topic_blog_service.handle_write_topic_blog(
+            topic,
+            with_thumbnail=False,
+        )
+    )
+
+    # Then
+    assert result == temp_topic_blog_dir / "005.md"
+    assert captured["topic"] == "운동"
+    assert captured["excludes"] == [
+        "개",
+        "Dog",
+        "고양이",
+        "Cat",
+        "의자",
+        "Chair",
+        "다리미",
+        "Iron",
+        "덤벨",
+        "Dumbbell",
+    ]
+    assert captured["topic_sequence"] == 1
+
+
+def test_topic_pool_has_enough_unique_topics():
+    """`topic_pool` should keep enough unique topics for automation."""
+    # Given
+    topic_pool = TOPIC_PROMPT["topic_pool"]
+
+    # When
+    unique_topics = set(topic_pool)
+
+    # Then
+    assert len(topic_pool) >= 100
+    assert len(unique_topics) == len(topic_pool)
+    assert "야채" not in topic_pool
+    assert "부엌" not in topic_pool
+
+
+def test_topic_blog_writer_omits_image_references_without_thumbnail(monkeypatch):
+    """`TopicBlogWriter` should omit thumbnail references when thumbnail generation is disabled."""
+    writer = TopicBlogWriter()
+
+    async def write_topic_content(topic: str, excludes: list[str]):
+        return TopicBlogContent(
+            vocabs=["rabbit"],
+            content="## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.",
+        )
+
+    async def write_topic_meta(
+        topic: str,
+        content: TopicBlogContent,
+        topic_sequence: int,
+    ):
+        return TopicBlogMeta(
+            title="동물 영어로 배우기 #2 - 토끼 영어로",
+            alt="동물 영어 표현 썸네일",
+            description="'토끼'를 영어로 어떻게 표현하면 좋을까요?",
+            faqs=[
+                TopicFAQ(
+                    question="토끼를 영어로 어떻게 표현할까요?",
+                    answer="토끼는 영어로 'rabbit'이라고 표현해요.",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(writer, "_write_topic_content", write_topic_content)
+    monkeypatch.setattr(writer, "_write_topic_meta", write_topic_meta)
+
+    # Given
+    include_thumbnail = False
+
+    # When
+    result = asyncio.run(
+        writer.generate(
+            "동물",
+            3,
+            excludes=[],
+            topic_sequence=2,
+            include_thumbnail=include_thumbnail,
+        )
+    )
+
+    # Then
+    assert 'thumbnail: "./003.png"' not in result.content
+    assert "동물 영어 표현 썸네일" not in result.content
+    assert "![동물 영어 표현 썸네일](./003.png)" not in result.content


### PR DESCRIPTION
## Why
- Add a dedicated generator for topic vocabulary posts, separate from single-expression blog generation.
- Support automation by randomly selecting from a large configured topic pool when no topic is provided.
- Allow topics to repeat while preventing vocabulary reuse across all topic posts.
- Include topic vocabulary generation in the daily blog automation.

## Changes
- Added topic prompts, Pydantic AI writer, and write-topic-blog service/CLI command.
- Added a 135-item topic pool for automatic random topic selection.
- Added global existing-vocabulary exclusion across topic posts.
- Added topic thumbnail rendering with the shared “영어로 어떻게 표현할까?” subtitle, #FFBF1F accent styling, and optional no-thumbnail markdown output.
- Updated the daily blog workflow to generate 4 expression posts and then 1 random topic post, while surfacing failures from either generator.
- Added duplicate vocabulary guards, exact topic matching for sequence counts, no-space heading parsing, thumbnail failure safety, and focused tests.

## Testing
- PASS: uv run pytest tests/test_write_topic_blog.py tests/test_write_blog.py
- PASS: uv run python -m compileall engple main.py
- PASS: git diff --check
- PASS: workflow YAML parsed with PyYAML