### PR TITLE
✨ 첫 예문 정답 노출

### DIFF
--- a/src/hooks/useInteractiveList.ts
+++ b/src/hooks/useInteractiveList.ts
@@ -9,8 +9,10 @@ interface UseInteractiveListOptions {
   toggleAllButtonTextCollapse?: string
   toggleAllButtonClassName?: string
   useToggleAllBtn?: boolean
-  initialState?: "expanded" | "collapsed"
+  initialState?: InteractiveListInitialState
 }
+
+type InteractiveListInitialState = "expanded" | "collapsed" | "first-expanded"
 
 export function useInteractiveList(
   contentDependencies: DependencyList,
@@ -57,7 +59,7 @@ function useItemTogglers({
   itemSelector: string
   togglerSelector: string
   openAttribute: string
-  initialState: "expanded" | "collapsed"
+  initialState: InteractiveListInitialState
 }) {
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -79,11 +81,7 @@ function useItemTogglers({
     const togglers = document.querySelectorAll<HTMLElement>(togglerSelector)
     const items = document.querySelectorAll<HTMLElement>(itemSelector)
 
-    if (initialState === "expanded") {
-      for (const item of items) {
-        item.setAttribute(openAttribute, "true")
-      }
-    }
+    applyInitialItemState(items, openAttribute, initialState)
 
     for (const toggler of togglers) {
       toggler.addEventListener("click", handleClick)
@@ -101,6 +99,28 @@ function useItemTogglers({
     openAttribute,
     initialState,
   ])
+}
+
+function applyInitialItemState(
+  items: NodeListOf<HTMLElement>,
+  openAttribute: string,
+  initialState: InteractiveListInitialState,
+) {
+  if (initialState === "expanded") {
+    for (const item of items) {
+      item.setAttribute(openAttribute, "true")
+    }
+
+    return
+  }
+
+  for (const [index, item] of items.entries()) {
+    if (initialState === "first-expanded" && index === 0) {
+      item.setAttribute(openAttribute, "true")
+    } else {
+      item.removeAttribute(openAttribute)
+    }
+  }
 }
 
 function useToggleAllButton({
@@ -122,7 +142,7 @@ function useToggleAllButton({
   toggleAllButtonTextCollapse: string
   toggleAllButtonClassName: string
   useToggleAllBtn: boolean
-  initialState: "expanded" | "collapsed"
+  initialState: InteractiveListInitialState
 }) {
   useEffect(() => {
     let toggleAllButton: {
@@ -182,19 +202,20 @@ function setupToggleAllButton({
   toggleAllButtonTextExpand: string
   toggleAllButtonTextCollapse: string
   toggleAllButtonClassName: string
-  initialState: "expanded" | "collapsed"
+  initialState: InteractiveListInitialState
 }) {
   const listEl = document.querySelector(listSelector) as HTMLElement | null
   if (!listEl) return { button: undefined, handler: undefined }
 
   const button = document.createElement("button")
   button.className = toggleAllButtonClassName
+  const buttonState = getToggleAllButtonState(initialState)
 
   button.textContent =
-    initialState === "expanded"
+    buttonState === "expanded"
       ? toggleAllButtonTextCollapse
       : toggleAllButtonTextExpand
-  button.dataset.state = initialState
+  button.dataset.state = buttonState
 
   const handler = () => {
     const items = document.querySelectorAll<HTMLElement>(itemSelector)
@@ -223,4 +244,8 @@ function setupToggleAllButton({
   listEl.append(button)
 
   return { button, handler }
+}
+
+function getToggleAllButtonState(initialState: InteractiveListInitialState) {
+  return initialState === "expanded" ? "expanded" : "collapsed"
 }

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -83,7 +83,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
         })
       : html ?? ""
 
-  useInteractiveList([html], { initialState: "collapsed" })
+  useInteractiveList([html], { initialState: "first-expanded" })
   React.useEffect(() => {
     if (!site.googleAdsense || process.env.NODE_ENV === "development") return
 


### PR DESCRIPTION
## Why
- 예문 연습 UI에서 첫 방문자가 한국어 예문을 누르면 영어 정답이 열리는 구조를 즉시 이해할 수 있도록 첫 번째 정답을 기본 노출합니다.

## Changes
- interactive list 초기 상태에 첫 항목만 펼치는 옵션을 추가했습니다.
- 블로그 포스트 예문 리스트가 첫 번째 정답만 열린 상태로 시작하도록 변경했습니다.
- 첫 항목만 열린 상태에서도 전체 토글 버튼은 계속 "모두 펼치기" 액션으로 동작하게 유지했습니다.

## Validation
- yarn lint
- yarn typecheck
- agent-browser로 예문 페이지 초기 상태 및 전체 펼치기/숨기기 DOM 동작 확인