### PR TITLE
구조화 데이터 확장

### DIFF
--- a/src/components/navBar/searchBar.tsx
+++ b/src/components/navBar/searchBar.tsx
@@ -44,6 +44,8 @@ interface SearchSuggestionItem {
   body: string
 }
 
+const NO_ACTIVE_INDEX = -1
+
 const SearchBar: React.FC<SearchBarProps> = ({
   onClickOutside = () => {},
   onEscape = () => {},
@@ -53,7 +55,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   const searchInputRef = useRef<HTMLInputElement>(null)
   const resultListId = useId()
   const [searchTerm, setSearchTerm] = useState("")
-  const [activeIndex, setActiveIndex] = useState<number | undefined>()
+  const [activeIndex, setActiveIndex] = useState(NO_ACTIVE_INDEX)
   const [errorMessage, setErrorMessage] = useState("")
   const data = useStaticQuery<SearchBarQueryData>(graphql`
     query SearchBar {
@@ -207,7 +209,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   }, [onClickOutside])
 
   useEffect(() => {
-    setActiveIndex()
+    setActiveIndex(NO_ACTIVE_INDEX)
   }, [commandItems, searchTerm])
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -215,12 +217,12 @@ const SearchBar: React.FC<SearchBarProps> = ({
       event.preventDefault()
 
       if (commandItems.length === 0) {
-        setActiveIndex()
+        setActiveIndex(NO_ACTIVE_INDEX)
         return
       }
 
       setActiveIndex(currentIndex =>
-        currentIndex === undefined
+        currentIndex === NO_ACTIVE_INDEX
           ? 0
           : Math.min(currentIndex + 1, commandItems.length - 1),
       )
@@ -231,12 +233,12 @@ const SearchBar: React.FC<SearchBarProps> = ({
       event.preventDefault()
 
       if (commandItems.length === 0) {
-        setActiveIndex()
+        setActiveIndex(NO_ACTIVE_INDEX)
         return
       }
 
       setActiveIndex(currentIndex =>
-        currentIndex === undefined
+        currentIndex === NO_ACTIVE_INDEX
           ? commandItems.length - 1
           : Math.max(currentIndex - 1, 0),
       )
@@ -249,7 +251,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
     ) {
       event.preventDefault()
 
-      if (activeIndex !== undefined && commandItems[activeIndex]) {
+      if (activeIndex !== NO_ACTIVE_INDEX && commandItems[activeIndex]) {
         onSearch(commandItems[activeIndex].label)
         return
       }
@@ -296,7 +298,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   ) => {
     setSearchTerm(event.currentTarget.value)
     setErrorMessage("")
-    setActiveIndex()
+    setActiveIndex(NO_ACTIVE_INDEX)
   }
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -364,7 +366,8 @@ const SearchBar: React.FC<SearchBarProps> = ({
                 }
                 aria-controls={resultListId}
                 aria-activedescendant={
-                  activeIndex !== undefined && commandItems[activeIndex]?.id
+                  activeIndex !== NO_ACTIVE_INDEX &&
+                  commandItems[activeIndex]?.id
                     ? commandItems[activeIndex].id
                     : undefined
                 }

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -2,9 +2,11 @@ import React from "react"
 
 import { Helmet } from "react-helmet"
 import {
+  type CollectionPage,
   type EducationalOrganization,
   type Graph,
   type Thing,
+  type WebPage,
   type WebSite,
 } from "schema-dts"
 
@@ -28,6 +30,8 @@ interface SEOProperties {
   url?: Queries.Maybe<string>
   ogType?: "website" | "article"
   noIndex?: boolean
+  pageType?: "WebPage" | "CollectionPage"
+  mainEntityId?: string
 }
 
 const SEO: React.FC<SEOProperties> = ({
@@ -38,18 +42,36 @@ const SEO: React.FC<SEOProperties> = ({
   jsonLds = [],
   ogType = "website",
   noIndex = false,
+  pageType = "WebPage",
+  mainEntityId,
 }) => {
   const site = useSiteMetadata()
   const displayTitle = title || site.title || ""
   const description = desc || site.description || ""
   const canonicalUrl = url || undefined
+  const pageUrl = canonicalUrl || site.siteUrl || ""
   const ogImageUrl = getAbsoluteUrl(
     image || (defaultOpenGraphImage as string),
     site.siteUrl || "",
   )
+  const webPageJsonLd = canonicalUrl
+    ? [
+        createWebPageJsonLd({
+          description,
+          imageUrl: ogImageUrl,
+          language: site.lang ?? DEFAULT_LANG,
+          mainEntityId,
+          pageType,
+          siteUrl: site.siteUrl || "",
+          title: displayTitle,
+          url: pageUrl,
+        }),
+      ]
+    : []
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": [
+      ...webPageJsonLd,
       ...jsonLds,
       {
         "@type": "EducationalOrganization",
@@ -154,6 +176,44 @@ const SEO: React.FC<SEOProperties> = ({
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
     </Helmet>
   )
+}
+
+function createWebPageJsonLd({
+  description,
+  imageUrl,
+  language,
+  mainEntityId,
+  pageType,
+  siteUrl,
+  title,
+  url,
+}: {
+  description: string
+  imageUrl: string
+  language: string
+  mainEntityId?: string
+  pageType: "WebPage" | "CollectionPage"
+  siteUrl: string
+  title: string
+  url: string
+}) {
+  const pageJsonLd = {
+    "@type": pageType,
+    "@id": `${url}#webpage`,
+    name: title,
+    description,
+    url,
+    inLanguage: language,
+    isPartOf: { "@id": `${siteUrl}/#website` },
+    publisher: { "@id": `${siteUrl}/#organization` },
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: imageUrl,
+    },
+    ...(mainEntityId ? { mainEntity: { "@id": mainEntityId } } : {}),
+  }
+
+  return pageJsonLd as CollectionPage | WebPage
 }
 
 function getAbsoluteUrl(pathOrUrl: string, siteUrl: string) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
-import React, { useLayoutEffect, useState } from "react"
+import React, { useLayoutEffect, useMemo, useState } from "react"
 
 import { type PageProps, graphql } from "gatsby"
+import kebabCase from "lodash/kebabCase"
 import styled from "styled-components"
 
 import Adsense from "~/src/components/adsense"
@@ -9,8 +10,11 @@ import SEO from "~/src/components/seo"
 import useSiteMetadata from "~/src/hooks/useSiteMetadata"
 import Layout from "~/src/layouts/layout"
 import type Post from "~/src/types/Post"
+import { createPostItemListJsonLd } from "~/src/utils/structuredData"
 
 import { VERTICAL_AD_SLOT } from "../constants"
+
+const STRUCTURED_POST_LIST_LIMIT = 10
 
 const Home = ({
   pageContext,
@@ -19,22 +23,22 @@ const Home = ({
   const [posts, setPosts] = useState<Post[]>([])
   const currentCategory = pageContext.category
   const postData = data.allMarkdownRemark.edges
-  useLayoutEffect(() => {
-    const filteredPostData = currentCategory
+  const visiblePostData = useMemo(() => {
+    return currentCategory
       ? postData.filter(
           ({ node }) => node?.frontmatter?.category === currentCategory,
         )
       : postData
+  }, [currentCategory, postData])
+  useLayoutEffect(() => {
+    setPosts(
+      visiblePostData.map(({ node }) => {
+        const { id, fields, frontmatter } = node
+        const { slug } = fields!
+        const { title, desc, date, category, thumbnail, alt } = frontmatter!
+        const { childImageSharp } = thumbnail!
 
-    for (const { node } of filteredPostData) {
-      const { id, fields, frontmatter } = node
-      const { slug } = fields!
-      const { title, desc, date, category, thumbnail, alt } = frontmatter!
-      const { childImageSharp } = thumbnail!
-
-      setPosts(previousPost => [
-        ...previousPost,
-        {
+        return {
           id,
           slug,
           title,
@@ -43,17 +47,44 @@ const Home = ({
           category,
           thumbnail: childImageSharp?.id,
           alt,
-        },
-      ])
-    }
-  }, [currentCategory, postData])
+        }
+      }),
+    )
+  }, [visiblePostData])
 
   const site = useSiteMetadata()
   const postTitle = currentCategory || site.postTitle
+  const pagePath = currentCategory
+    ? `/category/${kebabCase(currentCategory)}/`
+    : "/"
+  const pageUrl = `${site.siteUrl}${pagePath}`
+  const itemListId = `${pageUrl}#itemlist`
+  const itemListJsonLd = createPostItemListJsonLd({
+    id: itemListId,
+    name: `${postTitle} 글 목록`,
+    posts: visiblePostData
+      .slice(0, STRUCTURED_POST_LIST_LIMIT)
+      .map(({ node }) => ({
+        slug: node.fields?.slug,
+        title: node.frontmatter?.title,
+      })),
+    siteUrl: site.siteUrl || "",
+  })
 
   return (
     <Layout>
-      <SEO />
+      <SEO
+        title={currentCategory ? `${postTitle} - ${site.title}` : undefined}
+        desc={
+          currentCategory
+            ? `${postTitle} 카테고리의 영어 표현 학습 글을 확인해보세요.`
+            : undefined
+        }
+        url={pageUrl}
+        pageType="CollectionPage"
+        mainEntityId={itemListId}
+        jsonLds={[itemListJsonLd]}
+      />
       <Main>
         <LeftAd>
           <Adsense

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { Link, type PageProps, graphql } from "gatsby"
 import kebabCase from "lodash/kebabCase"
 import {
-  type Article,
+  type BlogPosting,
   type BreadcrumbList,
   type FAQPage,
   type LearningResource,
@@ -28,6 +28,11 @@ import {
   initializeInlineAdsenseSlots,
   withInlineAdsense,
 } from "../utils/adsense"
+import {
+  createDefinedTermJsonLd,
+  createPracticeQuizJsonLd,
+  getExpressionTerm,
+} from "../utils/structuredData"
 
 interface DataProps {
   current: {
@@ -123,6 +128,10 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
   const description = desc || excerpt
   const faqItems = (faqs ?? []).filter(item => item?.question && item?.answer)
   const categoryPath = `/category/${kebabCase(category ?? "")}/`
+  const pageUrl = `${site.siteUrl}${slug}`
+  const articleId = `${pageUrl}#article`
+  const definedTermId = `${pageUrl}#definedterm`
+  const expression = getExpressionTerm({ category, title, faqs })
   const tocHeadings =
     faqItems.length > 0
       ? [
@@ -132,8 +141,8 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
       : headings
 
   const articleJsonLd = {
-    "@type": "Article",
-    "@id": `${site.siteUrl}${slug}`,
+    "@type": "BlogPosting",
+    "@id": articleId,
     headline: title,
     datePublished: date,
     dateModified: lastmod || date,
@@ -144,25 +153,26 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
       url: "https://github.com/engple",
     },
     description,
-    url: `${site.siteUrl}${slug}`,
+    url: pageUrl,
     thumbnailUrl: `${site.siteUrl}${ogImagePath}`,
     image: `${site.siteUrl}${ogImagePath}`,
     copyrightHolder: { "@id": `${site.siteUrl}/#organization` },
     publisher: { "@id": `${site.siteUrl}/#organization` },
+    isPartOf: { "@id": `${site.siteUrl}/#website` },
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${site.siteUrl}${slug}`,
+      "@id": `${pageUrl}#webpage`,
     },
     wordCount: html?.split(" ").length,
     speakable: {
       "@type": "SpeakableSpecification",
       cssSelector: ["article h1", "article h2", "[data-answer]"],
     },
-  } as Article
+  } as BlogPosting
 
   const breadcrumbJsonLd = {
     "@type": "BreadcrumbList",
-    "@id": `${site.siteUrl}${slug}#breadcrumb`,
+    "@id": `${pageUrl}#breadcrumb`,
     itemListElement: [
       {
         "@type": "ListItem",
@@ -184,7 +194,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
         "@type": "ListItem",
         position: 3,
         item: {
-          "@id": `${site.siteUrl}${slug}`,
+          "@id": pageUrl,
           name: title,
         },
       },
@@ -193,6 +203,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
 
   const faqJsonLd = {
     "@type": "FAQPage",
+    "@id": `${pageUrl}#faq`,
     mainEntity: faqItems.map(item => ({
       "@type": "Question",
       name: item?.question || "",
@@ -205,7 +216,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
 
   const learningResourceJsonLd = {
     "@type": "LearningResource",
-    "@id": `${site.siteUrl}${slug}#learningresource`,
+    "@id": `${pageUrl}#learningresource`,
     name: title,
     description,
     educationalLevel: "beginner",
@@ -214,6 +225,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
     isAccessibleForFree: true,
     teaches: title,
     assesses: title,
+    ...(expression ? { about: { "@id": definedTermId } } : {}),
     audience: {
       "@type": "EducationalAudience",
       educationalRole: "student",
@@ -222,11 +234,36 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
     provider: { "@id": `${site.siteUrl}/#organization` },
   } as LearningResource
 
+  const definedTermJsonLd = expression
+    ? createDefinedTermJsonLd({
+        category,
+        description,
+        expression,
+        id: definedTermId,
+        siteUrl: site.siteUrl || "",
+        url: pageUrl,
+      })
+    : undefined
+  const practiceQuizJsonLd = createPracticeQuizJsonLd({
+    aboutId: expression ? definedTermId : undefined,
+    expression,
+    html,
+    id: `${pageUrl}#practice-quiz`,
+    title: title || "",
+  })
   const jsonLds: Thing[] = [
     articleJsonLd,
     breadcrumbJsonLd,
     learningResourceJsonLd,
   ]
+
+  if (definedTermJsonLd) {
+    jsonLds.push(definedTermJsonLd)
+  }
+
+  if (practiceQuizJsonLd) {
+    jsonLds.push(practiceQuizJsonLd)
+  }
 
   if (faqItems.length > 0) {
     jsonLds.push(faqJsonLd)
@@ -237,10 +274,11 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
       <SEO
         title={title}
         desc={description}
-        url={`${site.siteUrl}${slug}`}
+        url={pageUrl}
         image={ogImagePath}
         jsonLds={jsonLds}
         ogType="article"
+        mainEntityId={articleId}
       />
       <main>
         <article ref={articleRef}>

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -166,9 +166,11 @@ export function createPracticeQuizJsonLd({
 }
 
 function getPracticeCards(html: string) {
-  return [...html.matchAll(/<li\b[^>]*data-interactive-item[^>]*>([\S\s]*?)<\/li>/gi)]
+  return [
+    ...html.matchAll(/<li\b[^>]*data-interactive-item[^>]*>([\S\s]*?)<\/li>/gi),
+  ]
     .map(match => createPracticeCard(match[1]))
-    .filter(Boolean)
+    .filter((card): card is PracticeCard => card !== undefined)
 }
 
 function createPracticeCard(block: string) {

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,224 @@
+import kebabCase from "lodash/kebabCase"
+import {
+  type DefinedTerm,
+  type ItemList,
+  type ListItem,
+  type Question,
+  type Quiz,
+} from "schema-dts"
+
+interface PostListItem {
+  slug?: string | null
+  title?: string | null
+}
+
+interface ExpressionSource {
+  category?: string | null
+  title?: string | null
+  faqs?:
+    | readonly {
+        answer?: string | null
+        question?: string | null
+      }[]
+    | readonly ({ answer?: string | null; question?: string | null } | null)[]
+    | null
+}
+
+interface PracticeCard {
+  question: string
+  answer: string
+}
+
+export function createPostItemListJsonLd({
+  id,
+  name,
+  posts,
+  siteUrl,
+}: {
+  id: string
+  name: string
+  posts: readonly PostListItem[]
+  siteUrl: string
+}) {
+  return {
+    "@type": "ItemList",
+    "@id": id,
+    name,
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    numberOfItems: posts.length,
+    itemListElement: posts.map((post, index) =>
+      createPostListItem(post, index, siteUrl),
+    ),
+  } as ItemList
+}
+
+function createPostListItem(
+  post: PostListItem,
+  index: number,
+  siteUrl: string,
+) {
+  return {
+    "@type": "ListItem",
+    position: index + 1,
+    name: post.title || "",
+    url: post.slug ? `${siteUrl}${post.slug}` : siteUrl,
+  } as ListItem
+}
+
+export function createDefinedTermJsonLd({
+  category,
+  description,
+  expression,
+  id,
+  siteUrl,
+  url,
+}: {
+  category?: string | null
+  description: string
+  expression: string
+  id: string
+  siteUrl: string
+  url: string
+}) {
+  return {
+    "@type": "DefinedTerm",
+    "@id": id,
+    name: expression,
+    description,
+    url,
+    inDefinedTermSet: {
+      "@type": "DefinedTermSet",
+      name: category ? `잉플 ${category} 표현 사전` : "잉플 영어 표현 사전",
+      url: category ? `${siteUrl}/category/${kebabCase(category)}/` : siteUrl,
+    },
+  } as DefinedTerm
+}
+
+export function getExpressionTerm({ category, title, faqs }: ExpressionSource) {
+  if (category !== "영어표현") return
+
+  return getExpressionFromFaqs(faqs) ?? getExpressionFromTitle(title)
+}
+
+function getExpressionFromFaqs(
+  faqs?:
+    | readonly ({ answer?: string | null; question?: string | null } | null)[]
+    | null,
+) {
+  for (const faq of faqs ?? []) {
+    const expression =
+      getFirstEnglishQuotedText(faq?.answer) ??
+      getFirstEnglishQuotedText(faq?.question)
+
+    if (expression) return expression
+  }
+
+  return
+}
+
+function getFirstEnglishQuotedText(text?: string | null) {
+  const quotedTexts = text?.matchAll(/["'‘“]([^"'’”]+)["'’”]/g) ?? []
+
+  for (const match of quotedTexts) {
+    const expression = match[1]?.trim()
+
+    if (expression && /[A-Za-z]/.test(expression)) return expression
+  }
+
+  return
+}
+
+function getExpressionFromTitle(title?: string | null) {
+  return getFirstEnglishQuotedText(title)
+}
+
+export function createPracticeQuizJsonLd({
+  aboutId,
+  expression,
+  html,
+  id,
+  title,
+}: {
+  aboutId?: string
+  expression?: string
+  html: string
+  id: string
+  title: string
+}) {
+  const cards = getPracticeCards(html)
+
+  if (cards.length === 0) return
+
+  return {
+    "@type": "Quiz",
+    "@id": id,
+    name: `${title} 연습 문제`,
+    about: aboutId
+      ? { "@id": aboutId }
+      : { "@type": "Thing", name: expression },
+    educationalAlignment: {
+      "@type": "AlignmentObject",
+      alignmentType: "educationalSubject",
+      targetName: "English language learning",
+    },
+    hasPart: cards.map(card => createPracticeQuestion(card)),
+  } as Quiz
+}
+
+function getPracticeCards(html: string) {
+  return [...html.matchAll(/<li\b[^>]*data-interactive-item[^>]*>([\S\s]*?)<\/li>/gi)]
+    .map(match => createPracticeCard(match[1]))
+    .filter(Boolean)
+}
+
+function createPracticeCard(block: string) {
+  const question = getElementTextByDataAttribute(block, "data-toggler")
+  const answer = getElementTextByDataAttribute(block, "data-answer")
+
+  if (!question || !answer) return
+
+  return { question, answer }
+}
+
+function getElementTextByDataAttribute(block: string, attribute: string) {
+  const pattern = new RegExp(
+    `<span[^>]*${attribute}[^>]*>([\\s\\S]*?)<\\/span>`,
+    "i",
+  )
+
+  return normalizeText(pattern.exec(block)?.[1])
+}
+
+function normalizeText(html?: string) {
+  return decodeHtmlEntities(stripHtml(html ?? ""))
+}
+
+function stripHtml(html: string) {
+  return html
+    .replaceAll(/<[^>]*>/g, " ")
+    .replaceAll(/\s+/g, " ")
+    .trim()
+}
+
+function decodeHtmlEntities(text: string) {
+  return text
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+}
+
+function createPracticeQuestion(card: PracticeCard) {
+  return {
+    "@type": "Question",
+    eduQuestionType: "Flashcard",
+    text: card.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: card.answer,
+    },
+  } as Question
+}


### PR DESCRIPTION
## Why
- 검색 엔진이 글, 학습 자료, 용어, 퀴즈, 목록 페이지의 관계를 더 명확히 이해하도록 JSON-LD를 확장합니다.

## Changes
- 공통 SEO JSON-LD에 WebPage/CollectionPage와 mainEntity 연결을 추가했습니다.
- 글 상세 JSON-LD를 BlogPosting 중심으로 정리하고 LearningResource, DefinedTerm, Quiz, FAQPage 식별자를 보강했습니다.
- 홈/카테고리 페이지에 최근 글 ItemList 구조화 데이터를 추가했습니다.
- 주제형 글에는 잘못된 DefinedTerm이 생성되지 않도록 표현 추출 조건을 제한했습니다.

## Validation
- yarn lint
- yarn build
- 생성 HTML JSON-LD 샘플 확인: topic/027, 852.nod-off, 처음부터-영어표현, 404

## Notes
- yarn typecheck는 기존 src/components/navBar/searchBar.tsx의 setActiveIndex() 인자 누락 오류로 실패합니다.