### PR TITLE
⚡ Gatsby 빌드 캐시 키 개선

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -45,8 +45,9 @@ jobs:
           path: |
             public
             .cache
-          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('public') }}
+          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-
             ${{ runner.os }}-gatsby-build-
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
## Why
- Gatsby Pages 배포에서 `gatsby-plugin-sharp` 이미지 재처리가 39분 이상 걸렸습니다.
- 기존 캐시 키가 `public` 해시 기반이라 새로 생성된 `.cache`/`public` 캐시가 안정적으로 다음 run에 이어지기 어려웠습니다.

## Changes
- Gatsby build cache key를 `yarn.lock` 해시 + `github.run_id` 기반으로 변경했습니다.
- 같은 lockfile 그룹의 최신 캐시를 우선 복원하도록 restore key를 추가했습니다.

## Verification
- YAML 파싱 확인: `yaml ok`
- Subagent review: no blocking findings