### PR TITLE
🔧 GitHub Actions Node 24 대응

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "scripts/uv.lock"

--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "18"
           cache: yarn
       - name: Restore Gatsby cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             public
@@ -56,7 +56,7 @@ jobs:
           NODE_OPTIONS: "--experimental-global-webcrypto"
         run: yarn build
       - name: Save Gatsby cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             public


### PR DESCRIPTION
## Why
- GitHub Actions is deprecating Node.js 20-based JavaScript actions.
- This repo was still using deprecated workflow action versions in the blog generation and Gatsby deployment pipelines.
- Updating to Node.js 24-compatible releases avoids forced-runtime fallback before June 2, 2026 and runner removal on September 16, 2026.

## Changes
- Upgraded actions/checkout from v4 to v6 in both workflows.
- Upgraded astral-sh/setup-uv from v5 to v8.1.0 in the blog workflow.
- Upgraded actions/setup-node from v4 to v6 in the Gatsby workflow.
- Upgraded actions/cache/restore and actions/cache/save from v4 to v5 in the Gatsby workflow.
- Upgraded actions/deploy-pages from v4 to v5 in the Gatsby workflow.