### PR TITLE
⚡ Gatsby 캐시 복원 방식 조정

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -39,16 +39,15 @@ jobs:
         with:
           node-version: "18"
           cache: yarn
-      - name: Restore cache
-        uses: actions/cache@v4
+      - name: Restore Gatsby cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             public
             .cache
-          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-
-            ${{ runner.os }}-gatsby-build-
       - name: Install dependencies
         run: yarn install
       - name: Build with Gatsby
@@ -56,6 +55,13 @@ jobs:
           PREFIX_PATHS: "true"
           NODE_OPTIONS: "--experimental-global-webcrypto"
         run: yarn build
+      - name: Save Gatsby cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            public
+            .cache
+          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Why
- 최근 두 Gatsby 배포 run 모두 캐시는 restore됐지만 넓은 `Linux-gatsby-build-` 캐시를 복원했습니다.
- Gatsby가 플러그인 변경을 감지해 `.cache`를 삭제했고, `gatsby-plugin-sharp`가 6,600개 이상의 이미지를 다시 처리하면서 30분 이상 소요됐습니다.

## Changes
- `actions/cache@v4`를 restore/save 단계로 분리했습니다.
- restore는 `yarn.lock` 해시 prefix 캐시만 찾도록 제한했습니다.
- save는 `run_id`/`run_attempt`를 포함한 고유 key로 저장해 다음 run이 최신 Gatsby 캐시를 복원할 수 있게 했습니다.
- 오래된 broad fallback `Linux-gatsby-build-`를 제거했습니다.

## Verification
- YAML 파싱 확인: `yaml ok`
- Subagent review: no blocking findings