### PR TITLE
🔧 GitHub Pages 배포 액션 업데이트

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -77,4 +77,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Why
- PR #18 has already been merged into main.
- GitHub Actions is still warning that actions/deploy-pages@v4 runs on the deprecated Node.js 20 runtime.
- Updating the Pages deployment action to a Node.js 24-compatible release removes the remaining deprecation warning.

## Changes
- Upgraded actions/deploy-pages from v4 to v5 in the Gatsby Pages deployment workflow.