### PR TITLE
🔧 GitHub Pages 아티팩트 업로드 액션 업데이트

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -63,7 +63,7 @@ jobs:
             .cache
           key: ${{ runner.os }}-gatsby-build-${{ hashFiles('yarn.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
 


### PR DESCRIPTION
## Why
- GitHub Actions is warning that the current Pages artifact upload path still runs on the deprecated Node.js 20 runtime through actions/upload-artifact@v4.
- The existing Gatsby Pages workflow uses actions/upload-pages-artifact@v3, which does not eliminate that warning.
- Updating to the current Pages artifact uploader removes the remaining Node.js 20 deprecation warning in this workflow.

## Changes
- Upgraded actions/upload-pages-artifact from v3 to v5 in the Gatsby Pages workflow.
- Kept actions/deploy-pages at v5, which is compatible with the updated uploader.

## Risk
- actions/upload-pages-artifact@v5 excludes hidden files by default.
- I found no evidence that this repo depends on hidden files in the generated Pages artifact, so this is low risk for the current workflow.