### PR TITLE
Improve root page SEO for Naver

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,7 +12,7 @@ const siteMetadata = {
   gtagTrackingId: meta.gtagTrackingId,
   googleAdsense: meta.googleAdsense,
   naverSiteVerification: meta.naverSiteVerification,
-  postTitle: "전체",
+  postTitle: "패턴으로 배우는 실전 영어 표현",
   menuLinks: [
     {
       link: "/",

--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -22,7 +22,7 @@
 const metaConfig = {
   title: "잉플 | 패턴으로 배우는 영어 공부",
   description:
-    "잉플은 한국어 예문으로 영어 패턴과 실전 표현을 배우는 영어 공부 사이트입니다. 상황별 표현, 발음, 연습 문제를 글 목록에서 바로 확인하세요.",
+    "잉플에서는 한국어 예문으로 영어 패턴과 실전 표현을 배울 수 있습니다. 상황별 표현, 발음, 연습 문제를 글 목록에서 바로 확인하세요.",
   author: "solaqua",
   siteUrl: "https://engple.github.io",
   lang: "ko-KR",

--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -20,8 +20,9 @@
 
 /** @type {MetaConfig} */
 const metaConfig = {
-  title: "잉플 | 패턴으로 배우는 영어 공부 🍎",
-  description: `영어 패턴 학습으로 자연스러운 영어 실력 향상! 🚀 잉플과 함께하는 효과적인 영어 공부법. 실용적인 영어 표현과, 즉각적인 연습 기회. 꾸준한 학습으로 영어가 술술 나오는 놀라운 경험을 해보세요. 지금 시작하세요! 😎`,
+  title: "잉플 | 패턴으로 배우는 영어 공부",
+  description:
+    "잉플은 한국어 예문으로 영어 패턴과 실전 표현을 배우는 영어 공부 사이트입니다. 상황별 표현, 발음, 연습 문제를 글 목록에서 바로 확인하세요.",
   author: "solaqua",
   siteUrl: "https://engple.github.io",
   lang: "ko-KR",

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -84,7 +84,7 @@ const SEO: React.FC<SEOProperties> = ({
           url: `${site.siteUrl}${defaultOpenGraphImage}`,
         },
         description:
-          "영어 패턴 학습으로 자연스러운 영어 실력 향상을 돕는 교육 사이트",
+          "영어 패턴 학습으로 자연스러운 영어 실력 향상을 돕는 학습 콘텐츠",
         sameAs: ["https://github.com/engple"],
       } as EducationalOrganization,
       {

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -112,7 +112,6 @@ const SEO: React.FC<SEOProperties> = ({
     <Helmet
       htmlAttributes={{ lang: site.lang ?? DEFAULT_LANG }}
       title={displayTitle}
-      titleTemplate={displayTitle.replace(" 🍎", "")}
       meta={
         [
           {
@@ -124,8 +123,12 @@ const SEO: React.FC<SEOProperties> = ({
             content: description?.slice(0, 160),
           },
           {
-            property: "naver-site-verification",
+            name: "naver-site-verification",
             content: site.naverSiteVerification,
+          },
+          {
+            property: "og:locale",
+            content: (site.lang ?? DEFAULT_LANG).replace("-", "_"),
           },
           {
             property: "og:description",
@@ -138,6 +141,10 @@ const SEO: React.FC<SEOProperties> = ({
           {
             property: "og:title",
             content: displayTitle,
+          },
+          {
+            property: "og:site_name",
+            content: site.title,
           },
           {
             property: "og:type",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -115,23 +115,31 @@ const Home = ({
                   : site.description}
               </HeroDescription>
             </HeroCopy>
-            <CategoryShelf aria-label="카테고리 탐색">
-              <CategoryPill $isActive={!currentCategory} to="/">
-                전체
-              </CategoryPill>
-              {categoryGroups.map(group => (
-                <CategoryPill
-                  key={group.fieldValue}
-                  $isActive={group.fieldValue === currentCategory}
-                  to={`/category/${kebabCase(group.fieldValue ?? "")}/`}
-                >
-                  <span>{group.fieldValue}</span>
-                  <CategoryCount>{group.totalCount}</CategoryCount>
+            <CategorySection aria-labelledby="category-heading">
+              <SectionHeading id="category-heading">카테고리</SectionHeading>
+              <CategoryShelf>
+                <CategoryPill $isActive={!currentCategory} to="/">
+                  전체
                 </CategoryPill>
-              ))}
-            </CategoryShelf>
+                {categoryGroups.map(group => (
+                  <CategoryPill
+                    key={group.fieldValue}
+                    $isActive={group.fieldValue === currentCategory}
+                    to={`/category/${kebabCase(group.fieldValue ?? "")}/`}
+                  >
+                    <span>{group.fieldValue}</span>
+                    <CategoryCount>{group.totalCount}</CategoryCount>
+                  </CategoryPill>
+                ))}
+              </CategoryShelf>
+            </CategorySection>
           </HeroSection>
-          <PostGrid posts={posts} />
+          <PostListSection aria-labelledby="post-list-heading">
+            <SectionHeading id="post-list-heading">
+              {currentCategory ? `${postTitle} 최신 글` : "최신 영어 표현 글"}
+            </SectionHeading>
+            <PostGrid posts={posts} />
+          </PostListSection>
         </Content>
         <RightAd>
           <Adsense
@@ -208,10 +216,30 @@ const HeroDescription = styled.p`
   line-height: 1.7;
 `
 
+const CategorySection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: var(--sizing-sm);
+`
+
+const SectionHeading = styled.h2`
+  margin-bottom: 0;
+  color: var(--color-text);
+  font-size: 1.125rem;
+  font-weight: var(--font-weight-bold);
+  line-height: 1.3;
+`
+
 const CategoryShelf = styled.nav`
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+`
+
+const PostListSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: var(--sizing-md);
 `
 
 const CategoryPill = styled(Link)<{ $isActive: boolean }>`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -103,12 +103,17 @@ const Home = ({
           />
         </LeftAd>
         <Content>
-          <HeroSection>
+          <HeroSection aria-labelledby="home-heading">
             <HeroCopy>
               <HeroEyebrow>
                 {currentCategory ? "Category Archive" : "Explore Engple"}
               </HeroEyebrow>
-              <PostTitle>{postTitle}</PostTitle>
+              <PostTitle id="home-heading">{postTitle}</PostTitle>
+              <HeroDescription>
+                {currentCategory
+                  ? `${postTitle} 카테고리의 영어 표현과 학습 글을 최신순으로 확인해보세요.`
+                  : site.description}
+              </HeroDescription>
             </HeroCopy>
             <CategoryShelf aria-label="카테고리 탐색">
               <CategoryPill $isActive={!currentCategory} to="/">
@@ -193,6 +198,14 @@ const PostTitle = styled.h1`
   @media (max-width: ${({ theme }) => theme.device.sm}) {
     font-size: 1.75rem;
   }
+`
+
+const HeroDescription = styled.p`
+  max-width: 40rem;
+  margin-top: 10px;
+  color: var(--color-text-2);
+  font-size: 1rem;
+  line-height: 1.7;
 `
 
 const CategoryShelf = styled.nav`

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -120,7 +120,10 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
         ]
       : headings
   const compactTocHeadings = tocHeadings.filter(heading => heading.depth === 2)
-  const hideLeadVisualOnDesktop = startsWithHeroImage(html, ogImagePath)
+  const hideLeadVisualOnDesktop = startsWithHeroImage(
+    html,
+    ogImagePath ?? undefined,
+  )
 
   const featureImageAlt = alt || title || ""
 

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -1,8 +1,11 @@
-export default interface Post
-  extends Pick<
+export default interface Post extends Omit<
+  Pick<
     Queries.MarkdownRemarkFrontmatter,
     "title" | "desc" | "date" | "category" | "alt"
-  > {
+  >,
+  "desc"
+> {
+  desc?: Queries.MarkdownRemarkFrontmatter["desc"]
   id: string
   slug: Queries.MarkdownRemarkFields["slug"]
   thumbnail?: string


### PR DESCRIPTION
## Why

Improve the root page SEO signals that Naver Search Advisor checks for the homepage, especially a meaningful single H1, concise Korean title/description metadata, canonical URL, semantic section structure, and Naver/Open Graph metadata.

## Changes

- Replaced the generic root heading text with a descriptive Korean H1 for English pattern learning.
- Added homepage/category intro copy so the page body describes the page intent near the H1.
- Added explicit H2 section headings for category navigation and the latest post list, giving the root page a cleaner H1 -> H2 -> H3 hierarchy.
- Tightened the global Korean title and description with natural wording that avoids calling Engple a "site" in the user-facing copy.
- Changed the Naver verification tag to `name="naver-site-verification"` and added Open Graph locale/site name.
- Adjusted `Post` nullability typing so generated Gatsby types pass strict type checking.

## Verification

- `yarn typecheck`
- `yarn lint`
- Reloaded `http://localhost:8000/` in the in-app browser and verified the updated root description and heading hierarchy: one H1, category/post-list H2s, and post-card H3s.
