### PR TITLE
교육 Q&A JSON-LD about 이름 추가

### DIFF
--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -29,6 +29,7 @@ import {
   withInlineAdsense,
 } from "../utils/adsense"
 import {
+  createAboutThingJsonLd,
   createDefinedTermJsonLd,
   createPracticeQuizJsonLd,
   getExpressionTerm,
@@ -216,7 +217,14 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
     isAccessibleForFree: true,
     teaches: title,
     assesses: title,
-    ...(expression ? { about: { "@id": definedTermId } } : {}),
+    ...(expression
+      ? {
+          about: createAboutThingJsonLd({
+            id: definedTermId,
+            name: expression,
+          }),
+        }
+      : {}),
     audience: {
       "@type": "EducationalAudience",
       educationalRole: "student",

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -153,9 +153,10 @@ export function createPracticeQuizJsonLd({
     "@type": "Quiz",
     "@id": id,
     name: `${title} 연습 문제`,
-    about: aboutId
-      ? { "@id": aboutId }
-      : { "@type": "Thing", name: expression },
+    about: createAboutThingJsonLd({
+      id: aboutId,
+      name: expression || title,
+    }),
     educationalAlignment: {
       "@type": "AlignmentObject",
       alignmentType: "educationalSubject",
@@ -163,6 +164,25 @@ export function createPracticeQuizJsonLd({
     },
     hasPart: cards.map(card => createPracticeQuestion(card)),
   } as Quiz
+}
+
+export function createAboutThingJsonLd({
+  id,
+  name,
+}: {
+  id?: string
+  name: string
+}) {
+  return id
+    ? {
+        "@type": "DefinedTerm",
+        "@id": id,
+        name,
+      }
+    : {
+        "@type": "Thing",
+        name,
+      }
 }
 
 function getPracticeCards(html: string) {


### PR DESCRIPTION
## Why

Google structured data inspection reports a non-critical missing `name` warning at the `about` path for education Q&A JSON-LD. The referenced term exists elsewhere in the graph, but the nested `about` object only exposed `@id`.

## Changes

- Include `@type`, `@id`, and `name` in expression-backed `LearningResource.about`.
- Reuse the same `about` shape for practice quiz JSON-LD, with a title fallback when there is no extracted expression.
