### PR TITLE
🔧 홈 카드 제목 heading 제거

### DIFF
--- a/src/components/postGrid/card/card.tsx
+++ b/src/components/postGrid/card/card.tsx
@@ -61,7 +61,7 @@ const Text = styled.div`
   }
 `
 
-const Title = styled.h3`
+const Title = styled.p`
   margin-top: var(--sizing-xs);
   font-size: var(--text-md);
   font-weight: var(--font-weight-bold);


### PR DESCRIPTION
## Why
- 루트 페이지 글 카드 제목이 모두 H3로 렌더링되어 heading 수가 과도하게 늘어나는 SEO 리스크를 줄입니다.

## Changes
- `PostGrid` 카드 제목을 `h3`에서 일반 문단 텍스트로 변경했습니다.
- 카드 제목의 기존 시각 스타일은 유지했습니다.

## Verification
- `rg -n "styled\\.h3|<h3|as=\\\"h3\\\"|component=\\\"h3\\\"" src/components/postGrid src/pages/index.tsx` 결과 없음
- `yarn eslint src/components/postGrid/card/card.tsx` 통과
- `yarn typecheck`는 기존 Gatsby `Queries` namespace 생성 부재로 실패
- `yarn build`는 최초 이미지 복사 ENOENT, `gatsby clean` 후 단일 워커 재시도는 `gatsby-plugin-sharp` 이미지 처리에서 장시간 정지해 중단
