### PR TITLE
🐛 루트 글 목록 SSR 렌더링 복구

### DIFF
--- a/src/components/postGrid/useInfiniteScroll.ts
+++ b/src/components/postGrid/useInfiniteScroll.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import type Post from "~/src/types/Post"
 
@@ -15,13 +15,15 @@ const useInfiniteScroll = ({
   maxPostNum: maxPostNumber = 10,
   offsetY = 400,
 }: UseInfiniteScrollProperties) => {
-  const [hasMore, setHasMore] = useState(false)
-  const [currentList, setCurrentList] = useState<Post[]>([])
+  const [hasMore, setHasMore] = useState(posts.length > maxPostNumber)
+  const [currentList, setCurrentList] = useState<Post[]>(() =>
+    posts.slice(0, maxPostNumber),
+  )
   const [observerLoading, setObserverLoading] = useState(false)
 
   const observer = useRef<IntersectionObserver>()
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     setHasMore(posts.length > maxPostNumber)
     setCurrentList(posts.slice(0, maxPostNumber))
     setObserverLoading(false)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useState } from "react"
+import React, { useMemo } from "react"
 
 import { Link, type PageProps, graphql } from "gatsby"
 import kebabCase from "lodash/kebabCase"
@@ -20,7 +20,6 @@ const Home = ({
   pageContext,
   data,
 }: PageProps<Queries.Query, Queries.MarkdownRemarkFrontmatter>) => {
-  const [posts, setPosts] = useState<Post[]>([])
   const currentCategory = pageContext.category
   const postData = data.allMarkdownRemark.edges
   const visiblePostData = useMemo(() => {
@@ -35,26 +34,25 @@ const Home = ({
       .filter(group => group.fieldValue)
       .sort((first, second) => second.totalCount - first.totalCount)
   }, [data.allMarkdownRemark.group])
-  useLayoutEffect(() => {
-    setPosts(
-      visiblePostData.map(({ node }) => {
-        const { id, fields, frontmatter } = node
-        const { slug } = fields!
-        const { title, desc, date, category, thumbnail, alt } = frontmatter!
-        const { childImageSharp } = thumbnail!
 
-        return {
-          id,
-          slug,
-          title,
-          desc,
-          date,
-          category,
-          thumbnail: childImageSharp?.id,
-          alt,
-        }
-      }),
-    )
+  const posts = useMemo(() => {
+    return visiblePostData.map(({ node }) => {
+      const { id, fields, frontmatter } = node
+      const { slug } = fields!
+      const { title, desc, date, category, thumbnail, alt } = frontmatter!
+      const { childImageSharp } = thumbnail!
+
+      return {
+        id,
+        slug,
+        title,
+        desc,
+        date,
+        category,
+        thumbnail: childImageSharp?.id,
+        alt,
+      }
+    })
   }, [visiblePostData])
 
   const site = useSiteMetadata()


### PR DESCRIPTION
## Why

루트 페이지의 글 목록이 클라이언트 effect 이후에만 채워져 정적 HTML에는 최신 글 링크가 비어 있었습니다. 네이버 크롤러가 JavaScript 실행 전 HTML을 기준으로 수집하면 루트 페이지의 내부 링크와 콘텐츠 신호가 약해질 수 있습니다.

## Changes

- 홈 페이지에서 글 목록 데이터를 렌더 단계에 계산하도록 변경했습니다.
- 무한 스크롤 훅의 초기 목록 state를 첫 페이지 글 목록으로 채워 SSR HTML에도 최신 글 카드가 포함되도록 했습니다.

## Verification

- `git diff --check`
- `yarn typecheck`는 기존 `Queries` 전역 타입 생성물이 없는 로컬 상태에서 실패했습니다.
- `yarn eslint src/pages/index.tsx src/components/postGrid/useInfiniteScroll.ts`는 `gatsby clean` 이후 `.cache/typegen/graphql.config.json` 부재로 실패했습니다.
- `GATSBY_CPU_COUNT=1 yarn build`는 병렬 `publicURL` 복사 오류를 피하기 위해 실행했으나, 마지막 HTML 단계가 장시간 정지되어 중단했습니다.
