### PR TITLE
✨ topic blog 중복 복구 추가

### DIFF
--- a/scripts/engple/core/topic_blog_writer.py
+++ b/scripts/engple/core/topic_blog_writer.py
@@ -10,6 +10,17 @@ from pydantic_ai.settings import ModelSettings
 
 from engple.config import config
 from engple.constants import TOPIC_PROMPT
+from engple.core.topic_vocab import (
+    TopicVocabCandidate,
+    extract_topic_heading_lines,
+    flatten_topic_vocabs,
+    normalize_topic_vocab,
+)
+
+MIN_TOPIC_VOCAB_COUNT = 5
+VOCAB_CANDIDATE_BATCH_SIZE = 12
+MAX_TOPIC_VOCAB_ATTEMPTS = 5
+MAX_TOPIC_CONTENT_ATTEMPTS = 3
 
 
 class TopicFAQ(BaseModel):
@@ -59,6 +70,15 @@ class TopicBlogContent(BaseModel):
         return value.replace("\\n", "\n").strip()
 
 
+class TopicVocabCandidates(BaseModel):
+    vocabs: list[TopicVocabCandidate] = Field(
+        description=dedent("""\
+            Candidate vocabulary pairs for the topic.
+            Generate more than needed so duplicate filtering can keep enough items.
+            """),
+    )
+
+
 class GeneratedTopicBlog(BaseModel):
     topic: str
     vocabs: list[str]
@@ -80,7 +100,8 @@ class TopicBlogWriter:
         include_thumbnail: bool = True,
     ) -> GeneratedTopicBlog:
         """Write a topic vocabulary blog for the given topic."""
-        topic_content = await self._write_topic_content(topic, excludes or [])
+        selected_vocabs = await self._select_topic_vocabs(topic, excludes or [])
+        topic_content = await self._write_topic_content(topic, selected_vocabs)
         topic_meta = await self._write_topic_meta(topic, topic_content, topic_sequence)
         final_content = self._get_final_content(
             topic_content,
@@ -95,29 +116,196 @@ class TopicBlogWriter:
             content=final_content,
         )
 
-    async def _write_topic_content(
+    async def _select_topic_vocabs(
         self, topic: str, excludes: list[str]
+    ) -> list[TopicVocabCandidate]:
+        """Select unique vocabulary before writing the post body."""
+        accepted_vocabs: list[TopicVocabCandidate] = []
+        accepted_keys: set[str] = set()
+        retry_excludes = [*excludes]
+
+        for attempt in range(MAX_TOPIC_VOCAB_ATTEMPTS):
+            candidates = await self._write_topic_vocab_candidates(topic, retry_excludes)
+            duplicate_vocabs = self._append_unique_vocabs(
+                accepted_vocabs,
+                accepted_keys,
+                candidates.vocabs,
+                retry_excludes,
+            )
+            if duplicate_vocabs:
+                logger.warning(
+                    "Rejected duplicate topic vocab candidates for '{}' on "
+                    "attempt {}/{}: {}",
+                    topic,
+                    attempt + 1,
+                    MAX_TOPIC_VOCAB_ATTEMPTS,
+                    ", ".join(duplicate_vocabs),
+                )
+
+            if len(accepted_vocabs) >= MIN_TOPIC_VOCAB_COUNT:
+                return accepted_vocabs[:MIN_TOPIC_VOCAB_COUNT]
+
+            retry_excludes = self._dedupe_excludes(
+                [
+                    *retry_excludes,
+                    *duplicate_vocabs,
+                    *self._format_vocab_candidates(accepted_vocabs),
+                ]
+            )
+
+        raise RuntimeError(
+            "Unable to generate enough unique topic vocabulary for "
+            f"'{topic}'. Accepted {len(accepted_vocabs)} of "
+            f"{MIN_TOPIC_VOCAB_COUNT} required items."
+        )
+
+    async def _write_topic_vocab_candidates(
+        self, topic: str, excludes: list[str]
+    ) -> TopicVocabCandidates:
+        """Generate vocabulary candidates for the topic."""
+        logger.info("🧩 주제별 영어 단어 후보 생성 중...")
+        vocab_agent = Agent(
+            self.model_content,
+            output_type=TopicVocabCandidates,
+            system_prompt=self._build_vocab_prompt(excludes),
+            retries=2,
+            model_settings=ModelSettings(temperature=0.7),
+        )
+        result = await vocab_agent.run(
+            f"topic: '{topic}'\ncount: {VOCAB_CANDIDATE_BATCH_SIZE}"
+        )
+        return cast(TopicVocabCandidates, result.output)
+
+    def _append_unique_vocabs(
+        self,
+        accepted_vocabs: list[TopicVocabCandidate],
+        accepted_keys: set[str],
+        candidates: list[TopicVocabCandidate],
+        excludes: list[str],
+    ) -> list[str]:
+        excluded_keys = {self._normalize_vocab(item) for item in excludes}
+        duplicate_vocabs: list[str] = []
+
+        for candidate in candidates:
+            candidate_vocabs = [candidate.korean, candidate.english]
+            candidate_keys = {
+                self._normalize_vocab(item) for item in candidate_vocabs
+            }
+            if "" in candidate_keys:
+                continue
+
+            if candidate_keys & excluded_keys or candidate_keys & accepted_keys:
+                duplicate_vocabs.extend(candidate_vocabs)
+                continue
+
+            accepted_vocabs.append(candidate)
+            accepted_keys.update(candidate_keys)
+
+        return self._dedupe_excludes(duplicate_vocabs)
+
+    async def _write_topic_content(
+        self, topic: str, vocabs: list[TopicVocabCandidate]
     ) -> TopicBlogContent:
         """Write the topic vocabulary blog body."""
         logger.info("✍️ 주제별 영어 블로그 작성 중...")
         content_agent = Agent(
             self.model_content,
             output_type=TopicBlogContent,
-            system_prompt=self._build_topic_prompt(excludes),
+            system_prompt=self._build_topic_prompt(),
             retries=2,
-            model_settings=ModelSettings(temperature=0.7),
+            model_settings=ModelSettings(temperature=0.5),
         )
-        result = await content_agent.run(f"topic: '{topic}'")
-        return cast(TopicBlogContent, result.output)
 
-    def _build_topic_prompt(self, excludes: list[str]) -> str:
-        prompt = TOPIC_PROMPT["prompt"].format(
-            example=TOPIC_PROMPT["content"]["example"]
+        for attempt in range(MAX_TOPIC_CONTENT_ATTEMPTS):
+            result = await content_agent.run(
+                self._build_topic_content_input(topic, vocabs)
+            )
+            topic_content = cast(TopicBlogContent, result.output)
+            drift = self._find_content_vocab_drift(topic_content, vocabs)
+            if not drift:
+                return TopicBlogContent(
+                    vocabs=[vocab.english for vocab in vocabs],
+                    content=topic_content.content,
+                )
+
+            logger.warning(
+                "Rejected topic content vocab drift for '{}' on attempt {}/{}: {}",
+                topic,
+                attempt + 1,
+                MAX_TOPIC_CONTENT_ATTEMPTS,
+                ", ".join(drift),
+            )
+
+        raise RuntimeError(
+            "Generated topic content did not match selected vocabulary for "
+            f"'{topic}'. Selected vocabulary: {self._format_vocab_list(vocabs)}"
+        )
+
+    def _find_content_vocab_drift(
+        self, content: TopicBlogContent, expected_vocabs: list[TopicVocabCandidate]
+    ) -> list[str]:
+        expected_headings = self._format_vocab_lines(expected_vocabs).splitlines()
+        generated_headings = extract_topic_heading_lines(content.content)
+
+        if generated_headings == expected_headings:
+            return []
+
+        expected = " | ".join(expected_headings)
+        generated = " | ".join(generated_headings)
+        return [f"expected [{expected}], got [{generated}]"]
+
+    def _build_topic_content_input(
+        self, topic: str, vocabs: list[TopicVocabCandidate]
+    ) -> str:
+        return (
+            f"topic: '{topic}'\n\n"
+            "Use exactly these vocabulary items, in this order:\n"
+            f"{self._format_vocab_lines(vocabs)}"
+        )
+
+    def _format_vocab_candidates(
+        self, candidates: list[TopicVocabCandidate]
+    ) -> list[str]:
+        return flatten_topic_vocabs(candidates)
+
+    def _format_vocab_lines(self, vocabs: list[TopicVocabCandidate]) -> str:
+        return "\n".join(
+            f"## {idx}. {vocab.korean} ({vocab.english})"
+            for idx, vocab in enumerate(vocabs, start=1)
+        )
+
+    def _format_vocab_list(self, vocabs: list[TopicVocabCandidate]) -> str:
+        return ", ".join(f"{vocab.korean} ({vocab.english})" for vocab in vocabs)
+
+    def _dedupe_excludes(self, excludes: list[str]) -> list[str]:
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for item in excludes:
+            key = self._normalize_vocab(item)
+            if not key or key in seen:
+                continue
+            deduped.append(item.strip())
+            seen.add(key)
+        return deduped
+
+    def _normalize_vocab(self, vocab: str) -> str:
+        return normalize_topic_vocab(vocab)
+
+    def _build_vocab_prompt(self, excludes: list[str]) -> str:
+        prompt = TOPIC_PROMPT["vocab_prompt"].format(
+            count=VOCAB_CANDIDATE_BATCH_SIZE
         )
         if excludes:
             prompt += "\n\n" + TOPIC_PROMPT["exclude_prompt"].format(
                 excludes=", ".join(excludes)
             )
+        return prompt
+
+    def _build_topic_prompt(self) -> str:
+        prompt = TOPIC_PROMPT["prompt"].format(
+            example=TOPIC_PROMPT["content"]["example"]
+        )
+        prompt += "\n\n" + TOPIC_PROMPT["selected_vocab_prompt"]
         return prompt
 
     async def _write_topic_meta(

--- a/scripts/engple/core/topic_vocab.py
+++ b/scripts/engple/core/topic_vocab.py
@@ -1,0 +1,38 @@
+import re
+
+from pydantic import BaseModel, Field
+
+TOPIC_HEADING_RE = re.compile(
+    r"^##\s+(?P<number>\d+)\.\s+(?P<korean>.+?)\s*\((?P<english>.+?)\)\s*$",
+    re.MULTILINE,
+)
+
+
+class TopicVocabCandidate(BaseModel):
+    korean: str = Field(description="Korean vocabulary item.")
+    english: str = Field(description="English vocabulary item.")
+
+
+def extract_topic_heading_lines(content: str) -> list[str]:
+    return [match.group(0).strip() for match in TOPIC_HEADING_RE.finditer(content)]
+
+
+def extract_topic_heading_vocabs(content: str) -> list[TopicVocabCandidate]:
+    return [
+        TopicVocabCandidate(
+            korean=match.group("korean").strip(),
+            english=match.group("english").strip(),
+        )
+        for match in TOPIC_HEADING_RE.finditer(content)
+    ]
+
+
+def flatten_topic_vocabs(vocabs: list[TopicVocabCandidate]) -> list[str]:
+    flattened: list[str] = []
+    for vocab in vocabs:
+        flattened.extend([vocab.korean, vocab.english])
+    return flattened
+
+
+def normalize_topic_vocab(vocab: str) -> str:
+    return vocab.strip().lower()

--- a/scripts/engple/prompts/topic.toml
+++ b/scripts/engple/prompts/topic.toml
@@ -32,6 +32,28 @@ Rules:
 ```
 """
 
+vocab_prompt = """Generate {count} Korean-English vocabulary candidate pairs for the given <TOPIC>.
+
+Rules:
+- The candidates are for Korean speakers learning practical English vocabulary.
+- Choose vocabulary items that belong to the same hierarchy level.
+- For a topic like "동물", use direct animal names such as "개", "고양이", "토끼", "소", "치타".
+- For a topic like "가구", use direct furniture names such as "소파", "의자", "테이블", "책상", "침대".
+- Do not mix parent/child levels in the same candidate list.
+- Prefer natural Korean terms that people actually use in daily life.
+- Prefer native Korean terms over loanwords when both are natural.
+- Return exactly {count} candidate pairs when possible.
+"""
+
+selected_vocab_prompt = """Use only the selected vocabulary items provided by the user message.
+
+Rules for selected vocabulary:
+- Use exactly the selected vocabulary items and no other vocabulary section headings.
+- Preserve the selected vocabulary order.
+- Each section heading must be formatted exactly as `## <NUMBER>. <KOREAN> (<ENGLISH>)`.
+- Do not replace, translate differently, merge, omit, or add selected vocabulary items.
+"""
+
 exclude_prompt = """Avoid these vocabulary items because they were already used for this topic:
 {excludes}
 """

--- a/scripts/engple/services/write_topic_blog.py
+++ b/scripts/engple/services/write_topic_blog.py
@@ -9,13 +9,14 @@ from loguru import logger
 from engple.config import config
 from engple.constants import TOPIC_PROMPT
 from engple.core.image_searcher import search_image
+from engple.core.topic_vocab import (
+    extract_topic_heading_vocabs,
+    flatten_topic_vocabs,
+    normalize_topic_vocab,
+)
 from engple.core.topic_blog_writer import GeneratedTopicBlog, TopicBlogWriter
 from engple.utils import render_topic_thumbnail
 
-TOPIC_HEADING_RE = re.compile(
-    r"^##\s+\d+\.\s+(.+?)\s*\((.+?)\)\s*$",
-    re.MULTILINE,
-)
 TITLE_RE = re.compile(r'^title:\s*["\']?(.+?)["\']?\s*$', re.MULTILINE)
 TOPIC_TITLE_RE = re.compile(r"^(.+?)\s+영어(?:로)?\s+(?:표현하기|배우기|단어 배우기)")
 
@@ -98,7 +99,9 @@ def _reject_duplicate_vocabs(
         _normalize_vocab(item)
         for item in [
             *generated_blog.vocabs,
-            *_extract_topic_heading_vocabs(generated_blog.content),
+            *flatten_topic_vocabs(
+                extract_topic_heading_vocabs(generated_blog.content)
+            ),
         ]
     }
     duplicates = sorted(item for item in generated if item in excluded)
@@ -109,15 +112,8 @@ def _reject_duplicate_vocabs(
         )
 
 
-def _extract_topic_heading_vocabs(content: str) -> list[str]:
-    vocabs: list[str] = []
-    for korean, english in TOPIC_HEADING_RE.findall(content):
-        vocabs.extend([korean.strip(), english.strip()])
-    return vocabs
-
-
 def _normalize_vocab(vocab: str) -> str:
-    return vocab.strip().lower()
+    return normalize_topic_vocab(vocab)
 
 
 def _get_next_topic_sequence(topic: str) -> int:
@@ -157,7 +153,7 @@ def _get_existing_topic_vocabs() -> list[str]:
     vocabs: list[str] = []
     for path in sorted(topic_dir.rglob("*.md")):
         content = path.read_text(encoding="utf-8")
-        vocabs.extend(_extract_topic_heading_vocabs(content))
+        vocabs.extend(flatten_topic_vocabs(extract_topic_heading_vocabs(content)))
     return vocabs
 
 

--- a/scripts/tests/test_write_topic_blog.py
+++ b/scripts/tests/test_write_topic_blog.py
@@ -9,9 +9,12 @@ from engple.core.topic_blog_writer import (
     GeneratedTopicBlog,
     TopicBlogContent,
     TopicBlogMeta,
+    TopicVocabCandidates,
     TopicBlogWriter,
     TopicFAQ,
 )
+from engple.core.topic_vocab import TopicVocabCandidate
+from engple.core import topic_blog_writer as topic_blog_writer_module
 from engple.services import write_topic_blog as write_topic_blog_service
 
 
@@ -435,10 +438,27 @@ def test_topic_blog_writer_omits_image_references_without_thumbnail(monkeypatch)
     """`TopicBlogWriter` should omit thumbnail references when thumbnail generation is disabled."""
     writer = TopicBlogWriter()
 
-    async def write_topic_content(topic: str, excludes: list[str]):
+    async def select_topic_vocabs(topic: str, excludes: list[str]):
+        return [
+            TopicVocabCandidate(korean="토끼", english="Rabbit"),
+            TopicVocabCandidate(korean="소", english="Cow"),
+            TopicVocabCandidate(korean="말", english="Horse"),
+            TopicVocabCandidate(korean="양", english="Sheep"),
+            TopicVocabCandidate(korean="돼지", english="Pig"),
+        ]
+
+    async def write_topic_content(
+        topic: str, vocabs: list[TopicVocabCandidate]
+    ):
         return TopicBlogContent(
-            vocabs=["rabbit"],
-            content="## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.",
+            vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
+            content=(
+                "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\n\n"
+                "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
+                "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
+                "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
+                "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
+            ),
         )
 
     async def write_topic_meta(
@@ -458,6 +478,7 @@ def test_topic_blog_writer_omits_image_references_without_thumbnail(monkeypatch)
             ],
         )
 
+    monkeypatch.setattr(writer, "_select_topic_vocabs", select_topic_vocabs)
     monkeypatch.setattr(writer, "_write_topic_content", write_topic_content)
     monkeypatch.setattr(writer, "_write_topic_meta", write_topic_meta)
 
@@ -479,3 +500,189 @@ def test_topic_blog_writer_omits_image_references_without_thumbnail(monkeypatch)
     assert 'thumbnail: "./003.png"' not in result.content
     assert "동물 영어 표현 썸네일" not in result.content
     assert "![동물 영어 표현 썸네일](./003.png)" not in result.content
+
+
+def test_topic_blog_writer_selects_unique_vocab_before_writing_content(monkeypatch):
+    """`TopicBlogWriter` should filter duplicate candidates before writing content."""
+    candidate_outputs = [
+        TopicVocabCandidates(
+            vocabs=[
+                TopicVocabCandidate(korean="개", english="Dog"),
+                TopicVocabCandidate(korean="토끼", english="Rabbit"),
+                TopicVocabCandidate(korean="소", english="Cow"),
+                TopicVocabCandidate(korean="말", english="Horse"),
+            ],
+        ),
+        TopicVocabCandidates(
+            vocabs=[
+                TopicVocabCandidate(korean="소", english="Cow"),
+                TopicVocabCandidate(korean="양", english="Sheep"),
+                TopicVocabCandidate(korean="돼지", english="Pig"),
+                TopicVocabCandidate(korean="닭", english="Chicken"),
+            ],
+        ),
+    ]
+    content_prompts: list[str] = []
+    generated_meta_prompt: dict[str, str] = {}
+
+    class FakeRunResult:
+        def __init__(self, output):
+            self.output = output
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, system_prompt, **kwargs):
+            self.output_type = output_type
+            self.system_prompt = system_prompt
+
+        async def run(self, prompt):
+            if self.output_type is TopicVocabCandidates:
+                return FakeRunResult(candidate_outputs.pop(0))
+
+            if self.output_type is TopicBlogContent:
+                content_prompts.append(prompt)
+                return FakeRunResult(
+                    TopicBlogContent(
+                        vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
+                        content=(
+                            "동물 표현을 배워볼게요.\n\n"
+                            "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\n\n"
+                            "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
+                            "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
+                            "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
+                            "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
+                        ),
+                    )
+                )
+
+            generated_meta_prompt["prompt"] = prompt
+            return FakeRunResult(
+                TopicBlogMeta(
+                    title="동물 영어로 배우기 #2 - 토끼, 소, 말 영어로",
+                    alt="동물 영어 표현 썸네일",
+                    description="'토끼', '소', '말'을 영어로 배워요.",
+                    faqs=[
+                        TopicFAQ(
+                            question="토끼를 영어로 어떻게 표현할까요?",
+                            answer="토끼는 영어로 'rabbit'이라고 표현해요.",
+                        )
+                    ],
+                )
+            )
+
+    monkeypatch.setattr(topic_blog_writer_module, "Agent", FakeAgent)
+
+    # Given
+    writer = TopicBlogWriter()
+
+    # When
+    result = asyncio.run(
+        writer.generate(
+            "동물",
+            5,
+            excludes=["개", "Dog"],
+            topic_sequence=2,
+            include_thumbnail=False,
+        )
+    )
+
+    # Then
+    assert "## 1. 토끼 (Rabbit)" in result.content
+    assert "## 2. 소 (Cow)" in result.content
+    assert "## 3. 말 (Horse)" in result.content
+    assert "## 4. 양 (Sheep)" in result.content
+    assert "## 5. 돼지 (Pig)" in result.content
+    assert "개 (Dog)" not in result.content
+    assert "닭 (Chicken)" not in result.content
+    assert result.vocabs == ["Rabbit", "Cow", "Horse", "Sheep", "Pig"]
+    assert len(content_prompts) == 1
+    assert "1. 토끼 (Rabbit)" in content_prompts[0]
+    assert "5. 돼지 (Pig)" in content_prompts[0]
+    assert "닭 (Chicken)" not in generated_meta_prompt["prompt"]
+
+
+def test_topic_blog_writer_retries_content_when_heading_format_drifts(monkeypatch):
+    """`TopicBlogWriter` should retry content that changes selected heading text."""
+    content_outputs = [
+        TopicBlogContent(
+            vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
+            content=(
+                "동물 표현을 배워볼게요.\n\n"
+                "## 9. 토끼 (rabbit)\n\n토끼를 뜻해요.\n\n"
+                "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
+                "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
+                "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
+                "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
+            ),
+        ),
+        TopicBlogContent(
+            vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
+            content=(
+                "동물 표현을 배워볼게요.\n\n"
+                "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\n\n"
+                "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
+                "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
+                "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
+                "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
+            ),
+        ),
+    ]
+
+    class FakeRunResult:
+        def __init__(self, output):
+            self.output = output
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, **kwargs):
+            self.output_type = output_type
+
+        async def run(self, prompt):
+            if self.output_type is TopicVocabCandidates:
+                return FakeRunResult(
+                    TopicVocabCandidates(
+                        vocabs=[
+                            TopicVocabCandidate(korean="토끼", english="Rabbit"),
+                            TopicVocabCandidate(korean="소", english="Cow"),
+                            TopicVocabCandidate(korean="말", english="Horse"),
+                            TopicVocabCandidate(korean="양", english="Sheep"),
+                            TopicVocabCandidate(korean="돼지", english="Pig"),
+                        ],
+                    )
+                )
+
+            if self.output_type is TopicBlogContent:
+                return FakeRunResult(content_outputs.pop(0))
+
+            return FakeRunResult(
+                TopicBlogMeta(
+                    title="동물 영어로 배우기 #2 - 토끼, 소, 말 영어로",
+                    alt="동물 영어 표현 썸네일",
+                    description="'토끼', '소', '말'을 영어로 배워요.",
+                    faqs=[
+                        TopicFAQ(
+                            question="토끼를 영어로 어떻게 표현할까요?",
+                            answer="토끼는 영어로 'rabbit'이라고 표현해요.",
+                        )
+                    ],
+                )
+            )
+
+    monkeypatch.setattr(topic_blog_writer_module, "Agent", FakeAgent)
+
+    # Given
+    writer = TopicBlogWriter()
+
+    # When
+    result = asyncio.run(
+        writer.generate(
+            "동물",
+            5,
+            excludes=[],
+            topic_sequence=2,
+            include_thumbnail=False,
+        )
+    )
+
+    # Then
+    assert "## 1. 토끼 (Rabbit)" in result.content
+    assert "## 9. 토끼 (rabbit)" not in result.content
+    assert content_outputs == []


### PR DESCRIPTION
## Why

Daily Blog Generation에서 topic 글 생성이 기존 topic vocab을 재사용하면 전체 topic 생성이 실패했습니다. 모델이 exclude prompt를 어길 수 있으므로, prompt 의존 대신 코드가 vocab 선택을 확정하고 본문을 검증해야 합니다.

## Changes

- topic 본문 생성 전에 vocab 후보를 먼저 생성합니다.
- 코드가 기존 exclude와 이미 선택한 후보를 기준으로 중복 vocab을 제거하고, 고유 vocab 5개를 확정합니다.
- 후보 단계에서 중복으로 버린 vocab은 warning 로그에 남깁니다.
- 확정된 5개 vocab만 본문 생성 prompt에 전달하고, 본문 heading 라인이 번호/표기/대소문자까지 정확히 같은지 검증합니다.
- 본문이 확정 vocab을 누락/변경/추가하면 최대 3회 재생성하고, 계속 어긋나면 선택 vocab을 포함해 실패합니다.
- topic heading parser와 vocab normalization을 `topic_vocab` 모듈로 모아 writer와 service가 같은 계약을 쓰게 했습니다.
- topic prompt에 vocab 후보 생성용 prompt와 확정 vocab 전용 본문 규칙을 추가했습니다.
- topic writer 테스트에 후보 중복 제거와 heading drift 재시도 회귀 케이스를 추가했습니다.

## Tests

- `uv run pytest tests/test_write_topic_blog.py`
- `uv run pytest`
