### PR TITLE
✨ topic blog 내부링크 추가

### DIFF
--- a/scripts/engple/core/__init__.py
+++ b/scripts/engple/core/__init__.py
@@ -6,6 +6,7 @@ from .batch_linker import BatchLinker, BatchResult
 from .blog_writer import BlogWriter
 from .candidate_meanings import CandidateMeaningCreator
 from .expression_candidates import ExpressionCandidateCreator
+from .expression_targets import build_linkable_expressions
 
 __all__ = [
     "ExpressionLinker",
@@ -15,4 +16,5 @@ __all__ = [
     "BatchResult",
     "CandidateMeaningCreator",
     "ExpressionCandidateCreator",
+    "build_linkable_expressions",
 ]

--- a/scripts/engple/core/batch_linker.py
+++ b/scripts/engple/core/batch_linker.py
@@ -55,6 +55,8 @@ class BatchLinker:
             return result
 
         content = target_path.read_text(encoding="utf-8")
+        original_content = content
+        existing_links = 0
 
         if self.max_links is not None:
             existing_links = self.context_detector.count_existing_links(content)
@@ -65,10 +67,17 @@ class BatchLinker:
                 return result
 
         for expr in expressions:
+            if (
+                self.max_links is not None
+                and existing_links + result.total_links_added >= self.max_links
+            ):
+                break
+
             content, link_added = self.linker.apply_link(content, expr)
             result.total_links_added += link_added
 
-        self._write_file(target_path, content)
+        if content != original_content:
+            self._write_file(target_path, content)
 
         return result
 

--- a/scripts/engple/core/expression_targets.py
+++ b/scripts/engple/core/expression_targets.py
@@ -1,0 +1,42 @@
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+from engple.models import Expression
+from engple.utils import generate_variations
+from engple.utils.expr_path import ExprPath, iter_expr_path
+
+
+def build_linkable_expressions(
+    *,
+    excluded_exprs: Iterable[str] = (),
+    excluded_paths: Iterable[Path] = (),
+    excluded_path: Callable[[Path], bool] | None = None,
+) -> list[Expression]:
+    """Build expression link targets from published expression posts."""
+    excluded_expr_set = set(excluded_exprs)
+    excluded_path_set = {path.resolve() for path in excluded_paths}
+    expressions: list[Expression] = []
+
+    for expr_path in iter_expr_path():
+        if expr_path.expr in excluded_expr_set:
+            continue
+        if expr_path.file_path.resolve() in excluded_path_set:
+            continue
+        if excluded_path is not None and excluded_path(expr_path.file_path):
+            continue
+
+        expressions.append(_build_expression(expr_path))
+
+    return expressions
+
+
+def _build_expression(expr_path: ExprPath) -> Expression:
+    return Expression(
+        base_form=expr_path.expr,
+        url_path=expr_path.url_path,
+        file_path=expr_path.file_path,
+        variations=generate_variations(expr_path.expr),
+    )
+
+
+__all__ = ["build_linkable_expressions"]

--- a/scripts/engple/services/link_all_expressions.py
+++ b/scripts/engple/services/link_all_expressions.py
@@ -1,10 +1,8 @@
 import sys
 from loguru import logger
 
-from engple.core import BatchLinker
-from engple.models import Expression
-from engple.utils import generate_variations, get_expr_path
-from engple.utils.expr_path import iter_expr_path
+from engple.core import BatchLinker, build_linkable_expressions
+from engple.utils import get_expr_path
 
 
 def handle_link_all_expressions(
@@ -43,16 +41,7 @@ def handle_link_all_expressions(
         sys.exit(1)
 
     logger.info("🔎 Discovering all other expressions...")
-    other_expressions = [
-        Expression(
-            base_form=expr_path.expr,
-            url_path=expr_path.url_path,
-            file_path=expr_path.file_path,
-            variations=generate_variations(expr_path.expr),
-        )
-        for expr_path in iter_expr_path()
-        if expr_path.expr != target_expr
-    ]
+    other_expressions = build_linkable_expressions(excluded_exprs=[target_expr])
     logger.info(f"Found {len(other_expressions)} other expressions to link.")
 
     batch = BatchLinker(

--- a/scripts/engple/services/link_topic_blogs.py
+++ b/scripts/engple/services/link_topic_blogs.py
@@ -1,0 +1,111 @@
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+from engple.config import config
+from engple.core import BatchLinker
+from engple.models import Expression
+from engple.utils import generate_variations
+from engple.utils.expr_path import iter_expr_path
+
+
+@dataclass
+class TopicBlogLinkingResult:
+    """Summarizes topic blog linking across one or more posts."""
+
+    files_processed: int = 0
+    files_modified: int = 0
+    links_added: int = 0
+
+
+def handle_link_topic_blogs(
+    max_links: int | None = None,
+    dry_run: bool = False,
+    verbose: bool = False,
+    target_paths: list[Path] | None = None,
+) -> TopicBlogLinkingResult:
+    """Link existing expression posts inside topic blog markdown files."""
+    if verbose:
+        logger.remove()
+        logger.add(lambda msg: print(msg, end=""), level="DEBUG")
+
+    if max_links is not None and max_links <= 0:
+        logger.error("max_links must be a positive integer or None for unlimited")
+        sys.exit(2)
+
+    topic_paths = _get_topic_paths(target_paths)
+    expressions = _get_expression_targets()
+    result = _link_topic_paths(topic_paths, expressions, max_links, dry_run)
+
+    logger.info("")
+    logger.info("📊 Topic Blog Link Results:")
+    logger.info(f"   Files processed: {result.files_processed}")
+    logger.info(f"   Files modified: {result.files_modified}")
+    logger.info(f"   Links added: {result.links_added}")
+
+    if dry_run:
+        logger.info("🔍 Dry run completed - no files were modified")
+    else:
+        logger.success("✅ Topic blog linking completed successfully!")
+
+    return result
+
+
+def _get_topic_paths(target_paths: list[Path] | None) -> list[Path]:
+    if target_paths is not None:
+        return [path for path in target_paths if _is_topic_post(path)]
+
+    topic_dir = config.blog_dir / "topic"
+    if not topic_dir.exists():
+        return []
+
+    return sorted(topic_dir.rglob("*.md"))
+
+
+def _is_topic_post(path: Path) -> bool:
+    try:
+        path.resolve().relative_to((config.blog_dir / "topic").resolve())
+    except ValueError:
+        return False
+    return path.suffix == ".md"
+
+
+def _get_expression_targets() -> list[Expression]:
+    return [
+        Expression(
+            base_form=expr_path.expr,
+            url_path=expr_path.url_path,
+            file_path=expr_path.file_path,
+            variations=generate_variations(expr_path.expr),
+        )
+        for expr_path in iter_expr_path()
+        if not _is_topic_post(expr_path.file_path)
+    ]
+
+
+def _link_topic_paths(
+    topic_paths: list[Path],
+    expressions: list[Expression],
+    max_links: int | None,
+    dry_run: bool,
+) -> TopicBlogLinkingResult:
+    result = TopicBlogLinkingResult()
+    batch = BatchLinker(dry_run=dry_run, max_links=max_links)
+
+    for topic_path in topic_paths:
+        file_result = batch.run(topic_path, expressions)
+        result.files_processed += 1
+        result.links_added += file_result.total_links_added
+        if file_result.total_links_added > 0:
+            result.files_modified += 1
+            logger.info(
+                f"Modified topic blog: {topic_path.name} "
+                f"(+{file_result.total_links_added} links)"
+            )
+
+    return result
+
+
+__all__ = ["TopicBlogLinkingResult", "handle_link_topic_blogs"]

--- a/scripts/engple/services/link_topic_blogs.py
+++ b/scripts/engple/services/link_topic_blogs.py
@@ -5,10 +5,8 @@ from pathlib import Path
 from loguru import logger
 
 from engple.config import config
-from engple.core import BatchLinker
+from engple.core import BatchLinker, build_linkable_expressions
 from engple.models import Expression
-from engple.utils import generate_variations
-from engple.utils.expr_path import iter_expr_path
 
 
 @dataclass
@@ -55,13 +53,25 @@ def handle_link_topic_blogs(
 
 def _get_topic_paths(target_paths: list[Path] | None) -> list[Path]:
     if target_paths is not None:
-        return [path for path in target_paths if _is_topic_post(path)]
+        return _validate_topic_paths(target_paths)
 
     topic_dir = config.blog_dir / "topic"
     if not topic_dir.exists():
         return []
 
     return sorted(topic_dir.rglob("*.md"))
+
+
+def _validate_topic_paths(paths: list[Path]) -> list[Path]:
+    topic_paths: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            raise ValueError(f"Topic blog not found: {path}")
+        if not _is_topic_post(path):
+            topic_dir = config.blog_dir / "topic"
+            raise ValueError(f"Expected topic blog path under {topic_dir}: {path}")
+        topic_paths.append(path)
+    return topic_paths
 
 
 def _is_topic_post(path: Path) -> bool:
@@ -73,16 +83,7 @@ def _is_topic_post(path: Path) -> bool:
 
 
 def _get_expression_targets() -> list[Expression]:
-    return [
-        Expression(
-            base_form=expr_path.expr,
-            url_path=expr_path.url_path,
-            file_path=expr_path.file_path,
-            variations=generate_variations(expr_path.expr),
-        )
-        for expr_path in iter_expr_path()
-        if not _is_topic_post(expr_path.file_path)
-    ]
+    return build_linkable_expressions(excluded_path=_is_topic_post)
 
 
 def _link_topic_paths(

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -8,6 +8,7 @@ from engple.services.write_blog import handle_write_blog
 from engple.services.write_topic_blog import handle_write_topic_blog
 from engple.services.link_expression import handle_link_expression
 from engple.services.link_all_expressions import handle_link_all_expressions
+from engple.services.link_topic_blogs import handle_link_topic_blogs
 
 app = typer.Typer(help="Automated English Expression Linking System")
 
@@ -117,6 +118,12 @@ def write_topic_blog(
         "--no-thumbnail",
         help="Do not generate a thumbnail image",
     ),
+    no_link: bool = typer.Option(False, "--no-link", help="Do not link expressions"),
+    max_links: int = typer.Option(
+        8,
+        "--max-links",
+        help="Maximum links per post (omit for unlimited)",
+    ),
 ) -> None:
     """Generate a topic vocabulary blog post."""
 
@@ -126,9 +133,29 @@ def write_topic_blog(
             excludes=exclude,
             with_thumbnail=not no_thumbnail,
         )
+        if not no_link:
+            handle_link_topic_blogs(max_links=max_links, target_paths=[blog_path])
         logger.info(f"Generated topic blog: {blog_path}\n")
 
     asyncio.run(_write_topic_blog())
+
+
+@app.command()
+def link_topic_blogs(
+    max_links: int = typer.Option(
+        8,
+        "--max-links",
+        help="Maximum links per topic post (omit for unlimited)",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview changes without applying them"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+) -> None:
+    """Link existing expression posts inside topic vocabulary blog posts."""
+    handle_link_topic_blogs(max_links=max_links, dry_run=dry_run, verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_e2e.py
+++ b/scripts/tests/test_e2e.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 from typer.testing import CliRunner
 from engple.config import config
+import main
 from main import app
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -104,3 +105,152 @@ class TestLinkAllExpressionsCommand:
 
         # then
         assert result.exit_code == 1
+
+
+class TestLinkTopicBlogsCommand:
+    """Test cases for the link-topic-blogs CLI command."""
+
+    def test_links_existing_topic_blogs_only(self, mock_blog_dir, runner):
+        """Backfill topic blog links without modifying regular expression posts."""
+        topic_path = mock_blog_dir / "topic" / "003.md"
+        expression_path = mock_blog_dir / "in-english" / "035.morning-person.md"
+        expression_before = expression_path.read_text(encoding="utf-8")
+        topic_path.write_text(
+            (
+                "---\n"
+                'title: "try to improve 영어로 배우기"\n'
+                'desc: "try to improve should stay unlinked here"\n'
+                "---\n\n"
+                "## try to improve heading\n\n"
+                '<span data-answer="try to improve">Attribute stays untouched.</span>\n\n'
+                "Already linked: [try to](/blog/in-english/117.try-to/).\n\n"
+                "I try to improve my English every day.\n"
+            ),
+            encoding="utf-8",
+        )
+
+        # Given
+        command = ["link-topic-blogs"]
+
+        # When
+        result = runner.invoke(app, command)
+
+        # Then
+        assert result.exit_code == 0
+        assert "Files processed: 2" in result.stdout
+        assert "Files modified: 1" in result.stdout
+        assert "Links added: 2" in result.stdout
+        assert expression_path.read_text(encoding="utf-8") == expression_before
+
+        content = topic_path.read_text(encoding="utf-8")
+        assert 'title: "try to improve 영어로 배우기"' in content
+        assert 'desc: "try to improve should stay unlinked here"' in content
+        assert "## try to improve heading" in content
+        assert 'data-answer="try to improve"' in content
+        assert "Already linked: [try to](/blog/in-english/117.try-to/)." in content
+        assert "I [try to](/blog/in-english/117.try-to/) [improve](/blog/in-english/394.improve/) my English every day." in content
+
+    def test_link_topic_blogs_respects_max_links(self, mock_blog_dir, runner):
+        """Backfill topic blog links should stop once max links is reached."""
+        topic_path = mock_blog_dir / "topic" / "003.md"
+        topic_path.write_text(
+            (
+                "---\n"
+                'title: "학습 영어로 배우기"\n'
+                "---\n\n"
+                "I try to improve my English every day.\n"
+            ),
+            encoding="utf-8",
+        )
+
+        # Given
+        command = ["link-topic-blogs", "--max-links", "1"]
+
+        # When
+        result = runner.invoke(app, command)
+
+        # Then
+        assert result.exit_code == 0
+        assert "Links added: 1" in result.stdout
+
+        content = topic_path.read_text(encoding="utf-8")
+        assert content.count("](/blog/in-english/") == 1
+
+    def test_write_topic_blog_links_generated_topic_post(
+        self,
+        mock_blog_dir,
+        runner,
+        monkeypatch,
+    ):
+        """`write-topic-blog` should link the generated topic post by default."""
+
+        async def write_generated_topic_blog(topic, excludes, with_thumbnail):
+            blog_path = mock_blog_dir / "topic" / "003.md"
+            blog_path.write_text(
+                (
+                    "---\n"
+                    'title: "학습 영어로 배우기"\n'
+                    "---\n\n"
+                    "I try to improve my English every day.\n"
+                ),
+                encoding="utf-8",
+            )
+            return blog_path
+
+        monkeypatch.setattr(
+            main,
+            "handle_write_topic_blog",
+            write_generated_topic_blog,
+        )
+
+        # Given
+        command = ["write-topic-blog", "학습", "--no-thumbnail"]
+
+        # When
+        result = runner.invoke(app, command)
+
+        # Then
+        assert result.exit_code == 0
+        assert "Generated topic blog:" in result.stdout
+
+        content = (mock_blog_dir / "topic" / "003.md").read_text(encoding="utf-8")
+        assert "I [try to](/blog/in-english/117.try-to/) [improve](/blog/in-english/394.improve/) my English every day." in content
+
+    def test_write_topic_blog_respects_no_link(
+        self,
+        mock_blog_dir,
+        runner,
+        monkeypatch,
+    ):
+        """`write-topic-blog --no-link` should leave generated topic content unchanged."""
+
+        async def write_generated_topic_blog(topic, excludes, with_thumbnail):
+            blog_path = mock_blog_dir / "topic" / "003.md"
+            blog_path.write_text(
+                (
+                    "---\n"
+                    'title: "학습 영어로 배우기"\n'
+                    "---\n\n"
+                    "I try to improve my English every day.\n"
+                ),
+                encoding="utf-8",
+            )
+            return blog_path
+
+        monkeypatch.setattr(
+            main,
+            "handle_write_topic_blog",
+            write_generated_topic_blog,
+        )
+
+        # Given
+        command = ["write-topic-blog", "학습", "--no-thumbnail", "--no-link"]
+
+        # When
+        result = runner.invoke(app, command)
+
+        # Then
+        assert result.exit_code == 0
+
+        content = (mock_blog_dir / "topic" / "003.md").read_text(encoding="utf-8")
+        assert "I try to improve my English every day." in content

--- a/scripts/tests/test_e2e.py
+++ b/scripts/tests/test_e2e.py
@@ -34,6 +34,26 @@ def runner():
     return CliRunner()
 
 
+@pytest.fixture
+def generated_topic_blog_writer(mock_blog_dir):
+    """Write a generated topic post fixture through the patched service boundary."""
+
+    async def write_generated_topic_blog(topic, excludes, with_thumbnail):
+        blog_path = mock_blog_dir / "topic" / "003.md"
+        blog_path.write_text(
+            (
+                "---\n"
+                'title: "학습 영어로 배우기"\n'
+                "---\n\n"
+                "I try to improve my English every day.\n"
+            ),
+            encoding="utf-8",
+        )
+        return blog_path
+
+    return write_generated_topic_blog
+
+
 class TestLinkExpressionCommand:
     """Test cases for the link-expression CLI command."""
 
@@ -112,6 +132,8 @@ class TestLinkTopicBlogsCommand:
 
     def test_links_existing_topic_blogs_only(self, mock_blog_dir, runner):
         """Backfill topic blog links without modifying regular expression posts."""
+        for path in (mock_blog_dir / "topic").glob("*.md"):
+            path.unlink()
         topic_path = mock_blog_dir / "topic" / "003.md"
         expression_path = mock_blog_dir / "in-english" / "035.morning-person.md"
         expression_before = expression_path.read_text(encoding="utf-8")
@@ -137,9 +159,8 @@ class TestLinkTopicBlogsCommand:
 
         # Then
         assert result.exit_code == 0
-        assert "Files processed: 2" in result.stdout
+        assert "Files processed: 1" in result.stdout
         assert "Files modified: 1" in result.stdout
-        assert "Links added: 2" in result.stdout
         assert expression_path.read_text(encoding="utf-8") == expression_before
 
         content = topic_path.read_text(encoding="utf-8")
@@ -181,26 +202,14 @@ class TestLinkTopicBlogsCommand:
         mock_blog_dir,
         runner,
         monkeypatch,
+        generated_topic_blog_writer,
     ):
         """`write-topic-blog` should link the generated topic post by default."""
-
-        async def write_generated_topic_blog(topic, excludes, with_thumbnail):
-            blog_path = mock_blog_dir / "topic" / "003.md"
-            blog_path.write_text(
-                (
-                    "---\n"
-                    'title: "학습 영어로 배우기"\n'
-                    "---\n\n"
-                    "I try to improve my English every day.\n"
-                ),
-                encoding="utf-8",
-            )
-            return blog_path
 
         monkeypatch.setattr(
             main,
             "handle_write_topic_blog",
-            write_generated_topic_blog,
+            generated_topic_blog_writer,
         )
 
         # Given
@@ -221,26 +230,14 @@ class TestLinkTopicBlogsCommand:
         mock_blog_dir,
         runner,
         monkeypatch,
+        generated_topic_blog_writer,
     ):
         """`write-topic-blog --no-link` should leave generated topic content unchanged."""
-
-        async def write_generated_topic_blog(topic, excludes, with_thumbnail):
-            blog_path = mock_blog_dir / "topic" / "003.md"
-            blog_path.write_text(
-                (
-                    "---\n"
-                    'title: "학습 영어로 배우기"\n'
-                    "---\n\n"
-                    "I try to improve my English every day.\n"
-                ),
-                encoding="utf-8",
-            )
-            return blog_path
 
         monkeypatch.setattr(
             main,
             "handle_write_topic_blog",
-            write_generated_topic_blog,
+            generated_topic_blog_writer,
         )
 
         # Given
@@ -254,3 +251,35 @@ class TestLinkTopicBlogsCommand:
 
         content = (mock_blog_dir / "topic" / "003.md").read_text(encoding="utf-8")
         assert "I try to improve my English every day." in content
+
+    def test_write_topic_blog_fails_when_generated_path_is_not_topic_post(
+        self,
+        mock_blog_dir,
+        runner,
+        monkeypatch,
+    ):
+        """`write-topic-blog` should fail if the generated path is not a topic post."""
+
+        async def write_non_topic_blog(topic, excludes, with_thumbnail):
+            blog_path = mock_blog_dir / "in-english" / "999.generated.md"
+            blog_path.write_text(
+                "I try to improve my English every day.\n",
+                encoding="utf-8",
+            )
+            return blog_path
+
+        monkeypatch.setattr(
+            main,
+            "handle_write_topic_blog",
+            write_non_topic_blog,
+        )
+
+        # Given
+        command = ["write-topic-blog", "학습", "--no-thumbnail"]
+
+        # When
+        result = runner.invoke(app, command)
+
+        # Then
+        assert result.exit_code == 1
+        assert "Expected topic blog path under" in str(result.exception)


### PR DESCRIPTION
## Why

Topic vocabulary posts were generated without the internal expression links that regular blog posts receive. This adds the same internal-linking capability for newly generated topic posts and provides a backfill command for existing topic posts.

## Changes

- Add a topic blog linking service that scans `blog/topic` markdown and links existing expression posts.
- Run topic linking by default after `write-topic-blog`, with `--no-link` and `--max-links` controls.
- Add `link-topic-blogs` for backfilling existing topic posts, with dry-run and verbose options.
- Centralize expression link target construction so batch and topic linking share the same target-building path.
- Validate explicit topic post targets so generated-path mismatches fail instead of silently reporting success.
- Tighten batch linking so `max_links` is enforced while adding links and unchanged files are not rewritten.
- Cover generated topic linking, backfill behavior, skip contexts, topic-only targeting, invalid generated paths, and max-link limits in CLI tests.

## Tests

- `uv run pytest`
