### PR TITLE
🐛 루트 HTML 유효성 복구

### DIFF
--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -22,7 +22,7 @@
 const metaConfig = {
   title: "잉플 | 패턴으로 배우는 영어 공부",
   description:
-    "잉플에서는 한국어 예문으로 영어 패턴과 실전 표현을 배울 수 있습니다. 상황별 표현, 발음, 연습 문제를 글 목록에서 바로 확인하세요.",
+    "잉플에서는 한국어 예문으로 영어 패턴과 실전 표현을 배울 수 있습니다. 상황별 표현, 발음, 연습 문제를 최신 글에서 바로 확인하세요.",
   author: "solaqua",
   siteUrl: "https://engple.github.io",
   lang: "ko-KR",

--- a/src/components/postGrid/postGrid.tsx
+++ b/src/components/postGrid/postGrid.tsx
@@ -14,7 +14,7 @@ interface PostGridProperties {
 }
 
 const PostGrid: React.FC<PostGridProperties> = ({ posts }) => {
-  const scrollEdgeReference = useRef<HTMLDivElement>(null)
+  const scrollEdgeReference = useRef<HTMLLIElement>(null)
   const currentList = useInfiniteScroll({
     posts,
     scrollEdgeRef: scrollEdgeReference,
@@ -42,7 +42,7 @@ const PostGrid: React.FC<PostGridProperties> = ({ posts }) => {
           </List>
         )
       })}
-      <div ref={scrollEdgeReference} />
+      <ScrollEdge ref={scrollEdgeReference} aria-hidden="true" />
     </Grid>
   )
 }
@@ -93,6 +93,14 @@ const List = styled.li`
   @media (max-width: ${({ theme }) => theme.device.sm}) {
     grid-column: span 2;
   }
+`
+
+const ScrollEdge = styled.li`
+  grid-column: 1 / -1;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
 `
 
 export default PostGrid

--- a/src/components/postGrid/useInfiniteScroll.ts
+++ b/src/components/postGrid/useInfiniteScroll.ts
@@ -4,7 +4,7 @@ import type Post from "~/src/types/Post"
 
 interface UseInfiniteScrollProperties {
   posts: Post[]
-  scrollEdgeRef: React.RefObject<HTMLDivElement>
+  scrollEdgeRef: React.RefObject<HTMLLIElement>
   maxPostNum: number
   offsetY: number
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,12 +9,13 @@ import PostGrid from "~/src/components/postGrid"
 import SEO from "~/src/components/seo"
 import useSiteMetadata from "~/src/hooks/useSiteMetadata"
 import Layout from "~/src/layouts/layout"
-import type Post from "~/src/types/Post"
 import { createPostItemListJsonLd } from "~/src/utils/structuredData"
 
 import { VERTICAL_AD_SLOT } from "../constants"
 
 const STRUCTURED_POST_LIST_LIMIT = 10
+const HOME_HERO_DESCRIPTION =
+  "잉플에서는 한국어 예문으로 영어 패턴과 실전 표현을 배울 수 있습니다. 상황별 표현, 발음, 연습 문제를 최신 글에서 바로 확인하세요."
 
 const Home = ({
   pageContext,
@@ -110,7 +111,7 @@ const Home = ({
               <HeroDescription>
                 {currentCategory
                   ? `${postTitle} 카테고리의 영어 표현과 학습 글을 최신순으로 확인해보세요.`
-                  : site.description}
+                  : HOME_HERO_DESCRIPTION}
               </HeroDescription>
             </HeroCopy>
             <CategorySection aria-labelledby="category-heading">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,8 +14,6 @@ import { createPostItemListJsonLd } from "~/src/utils/structuredData"
 import { VERTICAL_AD_SLOT } from "../constants"
 
 const STRUCTURED_POST_LIST_LIMIT = 10
-const HOME_HERO_DESCRIPTION =
-  "잉플에서는 한국어 예문으로 영어 패턴과 실전 표현을 배울 수 있습니다. 상황별 표현, 발음, 연습 문제를 최신 글에서 바로 확인하세요."
 
 const Home = ({
   pageContext,
@@ -111,7 +109,7 @@ const Home = ({
               <HeroDescription>
                 {currentCategory
                   ? `${postTitle} 카테고리의 영어 표현과 학습 글을 최신순으로 확인해보세요.`
-                  : HOME_HERO_DESCRIPTION}
+                  : site.description}
               </HeroDescription>
             </HeroCopy>
             <CategorySection aria-labelledby="category-heading">


### PR DESCRIPTION
## Why

네이버는 루트 페이지가 비정상적으로 보이면 개별 글 노출까지 같이 약해질 수 있습니다. 배포 HTML을 다시 확인해보니 글 링크 SSR은 복구되어 있었지만, 루트 본문 HTML에 실제 NUL 바이트 2개가 들어가고 `ul`의 직접 자식으로 스크롤 감지용 `div`가 렌더링되는 문제가 남아 있었습니다.

## Changes

- 루트 페이지가 첫 SSR부터 최신 글 10개와 ItemList JSON-LD를 채우도록 복구합니다.
- `site.description` 문구를 clean한 문장으로 바꾸고 루트 본문과 meta description이 같은 값을 쓰게 합니다.
- 무한스크롤 감지 노드를 `ul > div`에서 숨김 `li`로 바꿔 글 목록 HTML 구조를 유효하게 유지합니다.

## Verification

- `yarn eslint gatsby-meta-config.js src/pages/index.tsx src/components/postGrid/postGrid.tsx src/components/postGrid/useInfiniteScroll.ts`
- `git diff --check`
- 배포 HTML 사전 확인: 일반 요청과 Yeti User-Agent 요청 모두 HTTP 200, `/blog/` 링크 10개 SSR 확인
- 배포 HTML 사전 확인: 루트 본문에 `글 목록\0\0에서` NUL 바이트 2개 및 `ul > div` 구조 확인
