### PR TITLE
🐛 SEO 마크업 복구 및 null byte 제거

### DIFF
--- a/scripts/engple/core/blog_writer.py
+++ b/scripts/engple/core/blog_writer.py
@@ -354,7 +354,10 @@ class BlogWriter:
             .replace("~요", "")
         )
 
-        return full_content
+        return self._remove_null_bytes(full_content)
+
+    def _remove_null_bytes(self, text: str) -> str:
+        return text.replace("\x00", "")
 
     def _escape_text(self, text: str) -> str:
         """

--- a/scripts/engple/core/topic_blog_writer.py
+++ b/scripts/engple/core/topic_blog_writer.py
@@ -343,7 +343,7 @@ class TopicBlogWriter:
             include_thumbnail,
         )
         thumbnail_body = self._format_thumbnail_body(meta, blog_num, include_thumbnail)
-        return (
+        content = (
             "---\n"
             f'title: "{self._escape_text(meta.title)}"\n'
             'category: "주제별영어"\n'
@@ -356,6 +356,11 @@ class TopicBlogWriter:
             f"{thumbnail_body}"
             f"{content.content}\n"
         )
+
+        return self._remove_null_bytes(content)
+
+    def _remove_null_bytes(self, text: str) -> str:
+        return text.replace("\x00", "")
 
     def _format_thumbnail_frontmatter(
         self, meta: TopicBlogMeta, blog_num: int, include_thumbnail: bool

--- a/scripts/tests/test_write_blog.py
+++ b/scripts/tests/test_write_blog.py
@@ -4,7 +4,15 @@ from pathlib import Path
 import pytest
 
 from engple.config import config
-from engple.core.blog_writer import BlogWriter, GeneratedBlog
+from engple.core import blog_writer as blog_writer_module
+from engple.core.blog_writer import (
+    BlogContent,
+    BlogMeta,
+    BlogWriter,
+    FAQ,
+    GeneratedBlog,
+    RelatedExpression,
+)
 from engple.core.candidate_meanings import CandidateMeaningCreator
 from engple.core.expression_candidates import ExpressionCandidateCreator
 from engple.services import write_blog as write_blog_service
@@ -336,6 +344,8 @@ def test_handle_write_blog_rejects_expression_drift_to_existing_post(
 
 
 def test_generate_candidate_expressions_and_annotation_are_separate(monkeypatch):
+    """Candidate generation should return plain expressions before annotation."""
+
     async def fake_generate(self, existing_expressions: list[str], count: int):
         assert existing_expressions == ["drop off(내려주다)"]
         assert count == 2
@@ -348,9 +358,80 @@ def test_generate_candidate_expressions_and_annotation_are_separate(monkeypatch)
     monkeypatch.setattr(ExpressionCandidateCreator, "generate", fake_generate)
     monkeypatch.setattr(CandidateMeaningCreator, "annotate", fake_annotate)
 
+    # given
     writer = BlogWriter()
+
+    # when
     generated = asyncio.run(writer.generate_candidate_expressions(["drop off(내려주다)"], 2))
     annotated = asyncio.run(writer.annotate_candidate_expressions(generated))
 
+    # then
     assert generated == ["like", "set up"]
     assert annotated == ["like(좋아하다)", "set up(설정하다)"]
+
+
+def test_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
+    """`BlogWriter.generate` should remove null bytes while keeping FAQ frontmatter."""
+
+    class FakeRunResult:
+        def __init__(self, output):
+            self.output = output
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, **kwargs):
+            self.model = model
+            self.output_type = output_type
+
+        async def run(self, prompt):
+            if self.output_type is BlogContent:
+                return FakeRunResult(
+                    BlogContent(
+                        expression="hit\x00",
+                        korean_meanings=["치다"],
+                        title="'치다' 영어로 어떻게 표현할까 🥊 - 때리다 영어로\x00",
+                        body="본문입니다.\x00",
+                    )
+                )
+
+            if self.output_type is BlogMeta:
+                return FakeRunResult(
+                    BlogMeta(
+                        description="'치다'를 영어로 배워요.\x00",
+                        faqs=[
+                            FAQ(
+                                question="'hit'은 무슨 뜻인가요?\x00",
+                                answer="'hit'은 '치다'라는 뜻이에요.\x00",
+                            )
+                        ],
+                    )
+                )
+
+            if self.output_type == list[str]:
+                if self.model == config.model_examples:
+                    return FakeRunResult(["I hit the ball.\x00"])
+
+                return FakeRunResult(["공을 쳤어요.\x00"])
+
+            return FakeRunResult(
+                [
+                    RelatedExpression(
+                        expression="tap\x00",
+                        explanation="가볍게 치다는 뜻이에요.\x00",
+                        example="Tap the screen.\x00",
+                        translation="화면을 톡 치세요.\x00",
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(blog_writer_module, "Agent", FakeAgent)
+
+    # given
+    writer = BlogWriter(expression_count=1, recommendation_count=1)
+
+    # when
+    result = asyncio.run(writer.generate("hit", 1))
+
+    # then
+    assert "\x00" not in result.content
+    assert "faqs:" in result.content
+    assert "\"'hit'은 무슨 뜻인가요?\"" in result.content

--- a/scripts/tests/test_write_topic_blog.py
+++ b/scripts/tests/test_write_topic_blog.py
@@ -502,6 +502,82 @@ def test_topic_blog_writer_omits_image_references_without_thumbnail(monkeypatch)
     assert "![동물 영어 표현 썸네일](./003.png)" not in result.content
 
 
+def test_topic_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
+    """`TopicBlogWriter.generate` should remove null bytes while keeping FAQ frontmatter."""
+
+    class FakeRunResult:
+        def __init__(self, output):
+            self.output = output
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, **kwargs):
+            self.output_type = output_type
+
+        async def run(self, prompt):
+            if self.output_type is TopicVocabCandidates:
+                return FakeRunResult(
+                    TopicVocabCandidates(
+                        vocabs=[
+                            TopicVocabCandidate(korean="토끼", english="Rabbit"),
+                            TopicVocabCandidate(korean="소", english="Cow"),
+                            TopicVocabCandidate(korean="말", english="Horse"),
+                            TopicVocabCandidate(korean="양", english="Sheep"),
+                            TopicVocabCandidate(korean="돼지", english="Pig"),
+                        ],
+                    )
+                )
+
+            if self.output_type is TopicBlogContent:
+                return FakeRunResult(
+                    TopicBlogContent(
+                        vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
+                        content=(
+                            "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\x00\n\n"
+                            "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
+                            "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
+                            "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
+                            "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
+                        ),
+                    )
+                )
+
+            return FakeRunResult(
+                TopicBlogMeta(
+                    title="동물 영어로 배우기 #2 - 토끼 영어로\x00",
+                    alt="동물 영어 표현 썸네일\x00",
+                    description="'토끼'를 영어로 배워요.\x00",
+                    faqs=[
+                        TopicFAQ(
+                            question="토끼를 영어로 어떻게 표현할까요?\x00",
+                            answer="토끼는 영어로 'rabbit'이라고 표현해요.\x00",
+                        )
+                    ],
+                )
+            )
+
+    monkeypatch.setattr(topic_blog_writer_module, "Agent", FakeAgent)
+
+    # Given
+    writer = TopicBlogWriter()
+    include_thumbnail = False
+
+    # When
+    result = asyncio.run(
+        writer.generate(
+            "동물",
+            3,
+            excludes=[],
+            topic_sequence=2,
+            include_thumbnail=include_thumbnail,
+        )
+    )
+
+    # Then
+    assert "\x00" not in result.content
+    assert "faqs:" in result.content
+    assert '"토끼를 영어로 어떻게 표현할까요?"' in result.content
+
+
 def test_topic_blog_writer_selects_unique_vocab_before_writing_content(monkeypatch):
     """`TopicBlogWriter` should filter duplicate candidates before writing content."""
     candidate_outputs = [

--- a/src/components/postGrid/card/card.tsx
+++ b/src/components/postGrid/card/card.tsx
@@ -61,7 +61,7 @@ const Text = styled.div`
   }
 `
 
-const Title = styled.p`
+const Title = styled.h3`
   margin-top: var(--sizing-xs);
   font-size: var(--text-md);
   font-weight: var(--font-weight-bold);


### PR DESCRIPTION
## Why

Generated posts should not contain null bytes, and index cards should expose post titles with heading markup for crawler-friendly structure.

## Changes

- Restore home/category card titles from paragraph text to `h3` headings.
- Remove null bytes from generated English expression and topic post Markdown.
- Keep FAQ frontmatter intact while sanitizing generated output.
