### PR TITLE
🐛 생성 Markdown null byte 제거

### DIFF
--- a/scripts/engple/core/blog_writer.py
+++ b/scripts/engple/core/blog_writer.py
@@ -20,8 +20,7 @@ from engple.constants import (
 )
 from engple.core.candidate_meanings import CandidateMeaningCreator
 from engple.core.expression_candidates import ExpressionCandidateCreator
-from engple.utils import normalize_expression
-from engple.utils.null_bytes import remove_null_bytes
+from engple.utils import normalize_expression, remove_null_bytes
 
 
 class BlogContent(BaseModel):

--- a/scripts/engple/core/blog_writer.py
+++ b/scripts/engple/core/blog_writer.py
@@ -21,6 +21,7 @@ from engple.constants import (
 from engple.core.candidate_meanings import CandidateMeaningCreator
 from engple.core.expression_candidates import ExpressionCandidateCreator
 from engple.utils import normalize_expression
+from engple.utils.null_bytes import remove_null_bytes
 
 
 class BlogContent(BaseModel):
@@ -296,7 +297,9 @@ class BlogWriter:
         Get the final content for the given parameters
         """
         logger.info("💾 블로그 출력 저장 중...")
-        sanitized_expression = re.sub(r"\([^)]*\)", "", expression).strip()
+        sanitized_expression = remove_null_bytes(
+            re.sub(r"\([^)]*\)", "", expression).strip()
+        )
         try:
             content_body, content_footer = content.body.split("---\n\n")
         except ValueError:
@@ -306,8 +309,10 @@ class BlogWriter:
         # Build FAQ section
         faqs_section = ""
         for faq in blog_meta.faqs:
-            faqs_section += f'  - question: "{self._escape_text(faq.question)}"\n'
-            faqs_section += f'    answer: "{self._escape_text(faq.answer)}"\n'
+            question = self._escape_text(remove_null_bytes(faq.question))
+            answer = self._escape_text(remove_null_bytes(faq.answer))
+            faqs_section += f'  - question: "{question}"\n'
+            faqs_section += f'    answer: "{answer}"\n'
 
         # Build recommendations section
         recommendations_section = ""
@@ -331,9 +336,9 @@ class BlogWriter:
                 f'date: "{post_date}"\n'
                 f'thumbnail: "{blog_num:03d}.png"\n'
                 f"alt: \"'{sanitized_expression}' 영어표현 썸네일\"\n"
-                f'title: "{self._escape_text(content.title)}"\n'
+                f'title: "{self._escape_text(remove_null_bytes(content.title))}"\n'
                 f"desc: "
-                f'"{blog_meta.description} 다양한 예문을 통해서 연습하고 본인의 표현으로 만들어 보세요."\n'
+                f'"{self._escape_text(remove_null_bytes(blog_meta.description))} 다양한 예문을 통해서 연습하고 본인의 표현으로 만들어 보세요."\n'
                 f"faqs: \n"
                 f"{faqs_section}"
                 f"---\n\n"
@@ -354,10 +359,7 @@ class BlogWriter:
             .replace("~요", "")
         )
 
-        return self._remove_null_bytes(full_content)
-
-    def _remove_null_bytes(self, text: str) -> str:
-        return text.replace("\x00", "")
+        return remove_null_bytes(full_content)
 
     def _escape_text(self, text: str) -> str:
         """

--- a/scripts/engple/core/topic_blog_writer.py
+++ b/scripts/engple/core/topic_blog_writer.py
@@ -16,6 +16,7 @@ from engple.core.topic_vocab import (
     flatten_topic_vocabs,
     normalize_topic_vocab,
 )
+from engple.utils.null_bytes import remove_null_bytes
 
 MIN_TOPIC_VOCAB_COUNT = 5
 VOCAB_CANDIDATE_BATCH_SIZE = 12
@@ -343,9 +344,9 @@ class TopicBlogWriter:
             include_thumbnail,
         )
         thumbnail_body = self._format_thumbnail_body(meta, blog_num, include_thumbnail)
-        content = (
+        full_content = (
             "---\n"
-            f'title: "{self._escape_text(meta.title)}"\n'
+            f'title: "{self._escape_text(remove_null_bytes(meta.title))}"\n'
             'category: "주제별영어"\n'
             f'date: "{post_date}"\n'
             f"{thumbnail_frontmatter}"
@@ -357,10 +358,7 @@ class TopicBlogWriter:
             f"{content.content}\n"
         )
 
-        return self._remove_null_bytes(content)
-
-    def _remove_null_bytes(self, text: str) -> str:
-        return text.replace("\x00", "")
+        return remove_null_bytes(full_content)
 
     def _format_thumbnail_frontmatter(
         self, meta: TopicBlogMeta, blog_num: int, include_thumbnail: bool
@@ -369,7 +367,7 @@ class TopicBlogWriter:
             return ""
         return (
             f'thumbnail: "./{blog_num:03d}.png"\n'
-            f'alt: "{self._escape_text(meta.alt)}"\n'
+            f'alt: "{self._escape_text(remove_null_bytes(meta.alt))}"\n'
         )
 
     def _format_thumbnail_body(
@@ -386,7 +384,7 @@ class TopicBlogWriter:
         return date.isoformat(timespec="minutes")
 
     def _format_description(self, description: str) -> str:
-        escaped_description = self._escape_text(description)
+        escaped_description = self._escape_text(remove_null_bytes(description))
         return (
             f"{escaped_description} 다양한 예문을 통해서 연습하고 "
             "본인의 표현으로 만들어 보세요."
@@ -395,8 +393,10 @@ class TopicBlogWriter:
     def _format_faqs(self, faqs: list[TopicFAQ]) -> str:
         faqs_section = ""
         for faq in faqs:
-            faqs_section += f'  - question: "{self._escape_text(faq.question)}"\n'
-            faqs_section += f'    answer: "{self._escape_text(faq.answer)}"\n'
+            question = self._escape_text(remove_null_bytes(faq.question))
+            answer = self._escape_text(remove_null_bytes(faq.answer))
+            faqs_section += f'  - question: "{question}"\n'
+            faqs_section += f'    answer: "{answer}"\n'
         return faqs_section
 
     def _escape_text(self, text: str) -> str:

--- a/scripts/engple/core/topic_blog_writer.py
+++ b/scripts/engple/core/topic_blog_writer.py
@@ -16,7 +16,7 @@ from engple.core.topic_vocab import (
     flatten_topic_vocabs,
     normalize_topic_vocab,
 )
-from engple.utils.null_bytes import remove_null_bytes
+from engple.utils import remove_null_bytes
 
 MIN_TOPIC_VOCAB_COUNT = 5
 VOCAB_CANDIDATE_BATCH_SIZE = 12

--- a/scripts/engple/services/sanitize_posts.py
+++ b/scripts/engple/services/sanitize_posts.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from loguru import logger
+
+from engple.config import config
+from engple.utils.null_bytes import (
+    NullByteRemovalResult,
+    collect_markdown_posts,
+    remove_null_bytes_from_post_files,
+)
+
+
+def handle_sanitize_posts(
+    *,
+    write: bool = False,
+    target_dir: Path | None = None,
+) -> list[NullByteRemovalResult]:
+    root = target_dir or config.blog_dir
+    results = remove_null_bytes_from_post_files(
+        collect_markdown_posts(root),
+        write=write,
+    )
+    changed_results = [result for result in results if result.changed]
+
+    action = "Updated" if write else "Would update"
+    for result in changed_results:
+        logger.info("{} {}\n", action, result.path)
+
+    logger.info(
+        "{} null bytes in {} of {} markdown post(s).\n",
+        action,
+        len(changed_results),
+        len(results),
+    )
+    return results
+
+
+__all__ = ["handle_sanitize_posts"]

--- a/scripts/engple/services/sanitize_posts.py
+++ b/scripts/engple/services/sanitize_posts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from loguru import logger
 
 from engple.config import config
-from engple.utils.null_bytes import (
+from engple.utils import (
     NullByteRemovalResult,
     collect_markdown_posts,
     remove_null_bytes_from_post_files,

--- a/scripts/engple/utils/__init__.py
+++ b/scripts/engple/utils/__init__.py
@@ -7,14 +7,24 @@ from .expr_path import (
     normalize_expression,
 )
 from .image import render_topic_thumbnail, url_to_file
+from .null_bytes import (
+    NullByteRemovalResult,
+    collect_markdown_posts,
+    remove_null_bytes,
+    remove_null_bytes_from_post_files,
+)
 
 __all__ = [
+    "NullByteRemovalResult",
     "clean_expression",
+    "collect_markdown_posts",
     "format_expression_seed",
     "generate_variations",
     "get_existing_expression_map",
     "get_expr_path",
     "normalize_expression",
+    "remove_null_bytes",
+    "remove_null_bytes_from_post_files",
     "render_topic_thumbnail",
     "url_to_file",
 ]

--- a/scripts/engple/utils/null_bytes.py
+++ b/scripts/engple/utils/null_bytes.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class NullByteRemovalResult:
+    path: Path
+    changed: bool
+
+
+def remove_null_bytes(text: str) -> str:
+    return text.replace("\x00", "")
+
+
+def remove_null_bytes_from_post_files(
+    paths: list[Path],
+    *,
+    write: bool,
+) -> list[NullByteRemovalResult]:
+    return [_remove_null_bytes_from_post_file(path, write=write) for path in paths]
+
+
+def _remove_null_bytes_from_post_file(
+    path: Path,
+    *,
+    write: bool,
+) -> NullByteRemovalResult:
+    original = path.read_text(encoding="utf-8")
+    cleaned = remove_null_bytes(original)
+    changed = cleaned != original
+
+    if changed and write:
+        path.write_text(cleaned, encoding="utf-8")
+
+    return NullByteRemovalResult(path=path, changed=changed)
+
+
+def collect_markdown_posts(root: Path) -> list[Path]:
+    return sorted(root.rglob("*.md"))

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -9,6 +9,7 @@ from engple.services.write_topic_blog import handle_write_topic_blog
 from engple.services.link_expression import handle_link_expression
 from engple.services.link_all_expressions import handle_link_all_expressions
 from engple.services.link_topic_blogs import handle_link_topic_blogs
+from engple.services.sanitize_posts import handle_sanitize_posts
 
 app = typer.Typer(help="Automated English Expression Linking System")
 
@@ -156,6 +157,18 @@ def link_topic_blogs(
 ) -> None:
     """Link existing expression posts inside topic vocabulary blog posts."""
     handle_link_topic_blogs(max_links=max_links, dry_run=dry_run, verbose=verbose)
+
+
+@app.command()
+def sanitize_posts(
+    write: bool = typer.Option(
+        False,
+        "--write",
+        help="Apply changes. Omit to preview affected posts only.",
+    ),
+) -> None:
+    """Remove null bytes from generated markdown posts."""
+    handle_sanitize_posts(write=write)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_null_bytes.py
+++ b/scripts/tests/test_null_bytes.py
@@ -1,0 +1,46 @@
+from engple.utils.null_bytes import (
+    collect_markdown_posts,
+    remove_null_bytes,
+    remove_null_bytes_from_post_files,
+)
+
+
+def test_remove_null_bytes_preserves_html():
+    """`remove_null_bytes` should remove only null bytes and preserve HTML text."""
+    # given
+    text = '<a href="/blog/test/">링\x00크</a><span data-answer>답\x00</span>'
+
+    # when
+    result = remove_null_bytes(text)
+
+    # then
+    assert result == '<a href="/blog/test/">링크</a><span data-answer>답</span>'
+
+
+def test_remove_null_bytes_from_post_files_requires_write_to_update_files(tmp_path):
+    """`remove_null_bytes_from_post_files` should write only when requested."""
+    # given
+    post = tmp_path / "001.md"
+    post.write_text(
+        (
+            "---\n"
+            'title: "질\x00문"\n'
+            "---\n\n"
+            '<span data-answer>HTML\x00 유지</span>\n'
+        ),
+        encoding="utf-8",
+    )
+    paths = collect_markdown_posts(tmp_path)
+
+    # when
+    preview_results = remove_null_bytes_from_post_files(paths, write=False)
+    preview_content = post.read_text(encoding="utf-8")
+    write_results = remove_null_bytes_from_post_files(paths, write=True)
+    written_content = post.read_text(encoding="utf-8")
+
+    # then
+    assert [result.changed for result in preview_results] == [True]
+    assert "\x00" in preview_content
+    assert [result.changed for result in write_results] == [True]
+    assert "\x00" not in written_content
+    assert '<span data-answer>HTML 유지</span>' in written_content

--- a/scripts/tests/test_null_bytes.py
+++ b/scripts/tests/test_null_bytes.py
@@ -1,4 +1,4 @@
-from engple.utils.null_bytes import (
+from engple.utils import (
     collect_markdown_posts,
     remove_null_bytes,
     remove_null_bytes_from_post_files,

--- a/scripts/tests/test_write_blog.py
+++ b/scripts/tests/test_write_blog.py
@@ -371,7 +371,7 @@ def test_generate_candidate_expressions_and_annotation_are_separate(monkeypatch)
 
 
 def test_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
-    """`BlogWriter.generate` should remove null bytes while keeping FAQ frontmatter."""
+    """`BlogWriter.generate` should remove null bytes while preserving HTML."""
 
     class FakeRunResult:
         def __init__(self, output):
@@ -388,8 +388,8 @@ def test_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
                     BlogContent(
                         expression="hit\x00",
                         korean_meanings=["치다"],
-                        title="'치다' 영어로 어떻게 표현할까 🥊 - 때리다 영어로\x00",
-                        body="본문입니다.\x00",
+                        title="'치다' 영어로 어떻게 표현할까 🥊\x00",
+                        body="본문 <strong>HTML\x00</strong>입니다.",
                     )
                 )
 
@@ -400,7 +400,10 @@ def test_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
                         faqs=[
                             FAQ(
                                 question="'hit'은 무슨 뜻인가요?\x00",
-                                answer="'hit'은 '치다'라는 뜻이에요.\x00",
+                                answer=(
+                                    "'hit'은 <strong>'치다'</strong>라는 "
+                                    "뜻이에요.\x00"
+                                ),
                             )
                         ],
                     )
@@ -434,4 +437,5 @@ def test_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
     # then
     assert "\x00" not in result.content
     assert "faqs:" in result.content
-    assert "\"'hit'은 무슨 뜻인가요?\"" in result.content
+    assert "<strong>'치다'</strong>" in result.content
+    assert "본문 <strong>HTML</strong>입니다." in result.content

--- a/scripts/tests/test_write_topic_blog.py
+++ b/scripts/tests/test_write_topic_blog.py
@@ -5,16 +5,16 @@ import pytest
 
 from engple.config import config
 from engple.constants import TOPIC_PROMPT
+from engple.core import topic_blog_writer as topic_blog_writer_module
 from engple.core.topic_blog_writer import (
     GeneratedTopicBlog,
     TopicBlogContent,
     TopicBlogMeta,
-    TopicVocabCandidates,
     TopicBlogWriter,
     TopicFAQ,
+    TopicVocabCandidates,
 )
 from engple.core.topic_vocab import TopicVocabCandidate
-from engple.core import topic_blog_writer as topic_blog_writer_module
 from engple.services import write_topic_blog as write_topic_blog_service
 
 
@@ -436,74 +436,6 @@ def test_topic_pool_has_enough_unique_topics():
 
 def test_topic_blog_writer_omits_image_references_without_thumbnail(monkeypatch):
     """`TopicBlogWriter` should omit thumbnail references when thumbnail generation is disabled."""
-    writer = TopicBlogWriter()
-
-    async def select_topic_vocabs(topic: str, excludes: list[str]):
-        return [
-            TopicVocabCandidate(korean="토끼", english="Rabbit"),
-            TopicVocabCandidate(korean="소", english="Cow"),
-            TopicVocabCandidate(korean="말", english="Horse"),
-            TopicVocabCandidate(korean="양", english="Sheep"),
-            TopicVocabCandidate(korean="돼지", english="Pig"),
-        ]
-
-    async def write_topic_content(
-        topic: str, vocabs: list[TopicVocabCandidate]
-    ):
-        return TopicBlogContent(
-            vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
-            content=(
-                "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\n\n"
-                "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
-                "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
-                "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
-                "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
-            ),
-        )
-
-    async def write_topic_meta(
-        topic: str,
-        content: TopicBlogContent,
-        topic_sequence: int,
-    ):
-        return TopicBlogMeta(
-            title="동물 영어로 배우기 #2 - 토끼 영어로",
-            alt="동물 영어 표현 썸네일",
-            description="'토끼'를 영어로 어떻게 표현하면 좋을까요?",
-            faqs=[
-                TopicFAQ(
-                    question="토끼를 영어로 어떻게 표현할까요?",
-                    answer="토끼는 영어로 'rabbit'이라고 표현해요.",
-                )
-            ],
-        )
-
-    monkeypatch.setattr(writer, "_select_topic_vocabs", select_topic_vocabs)
-    monkeypatch.setattr(writer, "_write_topic_content", write_topic_content)
-    monkeypatch.setattr(writer, "_write_topic_meta", write_topic_meta)
-
-    # Given
-    include_thumbnail = False
-
-    # When
-    result = asyncio.run(
-        writer.generate(
-            "동물",
-            3,
-            excludes=[],
-            topic_sequence=2,
-            include_thumbnail=include_thumbnail,
-        )
-    )
-
-    # Then
-    assert 'thumbnail: "./003.png"' not in result.content
-    assert "동물 영어 표현 썸네일" not in result.content
-    assert "![동물 영어 표현 썸네일](./003.png)" not in result.content
-
-
-def test_topic_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
-    """`TopicBlogWriter.generate` should remove null bytes while keeping FAQ frontmatter."""
 
     class FakeRunResult:
         def __init__(self, output):
@@ -532,7 +464,7 @@ def test_topic_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatc
                     TopicBlogContent(
                         vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
                         content=(
-                            "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\x00\n\n"
+                            "## 1. 토끼 (Rabbit)\n\n토끼를 뜻해요.\n\n"
                             "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
                             "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
                             "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
@@ -543,13 +475,13 @@ def test_topic_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatc
 
             return FakeRunResult(
                 TopicBlogMeta(
-                    title="동물 영어로 배우기 #2 - 토끼 영어로\x00",
-                    alt="동물 영어 표현 썸네일\x00",
-                    description="'토끼'를 영어로 배워요.\x00",
+                    title="동물 영어로 배우기 #2 - 토끼 영어로",
+                    alt="동물 영어 표현 썸네일",
+                    description="'토끼'를 영어로 어떻게 표현하면 좋을까요?",
                     faqs=[
                         TopicFAQ(
-                            question="토끼를 영어로 어떻게 표현할까요?\x00",
-                            answer="토끼는 영어로 'rabbit'이라고 표현해요.\x00",
+                            question="토끼를 영어로 어떻게 표현할까요?",
+                            answer="토끼는 영어로 'rabbit'이라고 표현해요.",
                         )
                     ],
                 )
@@ -573,9 +505,89 @@ def test_topic_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatc
     )
 
     # Then
+    assert 'thumbnail: "./003.png"' not in result.content
+    assert "동물 영어 표현 썸네일" not in result.content
+    assert "![동물 영어 표현 썸네일](./003.png)" not in result.content
+
+
+def test_topic_blog_writer_removes_null_bytes_from_generated_markdown(monkeypatch):
+    """`TopicBlogWriter.generate` should remove null bytes while preserving HTML."""
+
+    class FakeRunResult:
+        def __init__(self, output):
+            self.output = output
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, **kwargs):
+            self.output_type = output_type
+
+        async def run(self, prompt):
+            if self.output_type is TopicVocabCandidates:
+                return FakeRunResult(
+                    TopicVocabCandidates(
+                        vocabs=[
+                            TopicVocabCandidate(korean="토끼", english="Rabbit"),
+                            TopicVocabCandidate(korean="소", english="Cow"),
+                            TopicVocabCandidate(korean="말", english="Horse"),
+                            TopicVocabCandidate(korean="양", english="Sheep"),
+                            TopicVocabCandidate(korean="돼지", english="Pig"),
+                        ],
+                    )
+                )
+
+            if self.output_type is TopicBlogContent:
+                return FakeRunResult(
+                    TopicBlogContent(
+                        vocabs=["rabbit", "cow", "horse", "sheep", "pig"],
+                        content=(
+                            "## 1. 토끼 (Rabbit)\n\n"
+                            "토끼 <strong>HTML\x00</strong> 표현이에요.\n\n"
+                            "## 2. 소 (Cow)\n\n소를 뜻해요.\n\n"
+                            "## 3. 말 (Horse)\n\n말을 뜻해요.\n\n"
+                            "## 4. 양 (Sheep)\n\n양을 뜻해요.\n\n"
+                            "## 5. 돼지 (Pig)\n\n돼지를 뜻해요."
+                        ),
+                    )
+                )
+
+            return FakeRunResult(
+                TopicBlogMeta(
+                    title="동물 영어로 배우기 #2 - 토끼 영어로\x00",
+                    alt="동물 영어 표현 썸네일\x00",
+                    description="'토끼'를 영어로 어떻게 표현하면 좋을까요?\x00",
+                    faqs=[
+                        TopicFAQ(
+                            question="토끼를 영어로 어떻게 표현할까요?\x00",
+                            answer=(
+                                "토끼는 <strong>'rabbit'</strong>이라고 "
+                                "표현해요.\x00"
+                            ),
+                        )
+                    ],
+                )
+            )
+
+    monkeypatch.setattr(topic_blog_writer_module, "Agent", FakeAgent)
+
+    # Given
+    writer = TopicBlogWriter()
+
+    # When
+    result = asyncio.run(
+        writer.generate(
+            "동물",
+            3,
+            excludes=[],
+            topic_sequence=2,
+            include_thumbnail=False,
+        )
+    )
+
+    # Then
     assert "\x00" not in result.content
     assert "faqs:" in result.content
-    assert '"토끼를 영어로 어떻게 표현할까요?"' in result.content
+    assert "<strong>'rabbit'</strong>" in result.content
+    assert "토끼 <strong>HTML</strong> 표현이에요." in result.content
 
 
 def test_topic_blog_writer_selects_unique_vocab_before_writing_content(monkeypatch):


### PR DESCRIPTION
## Why

Generated Markdown should not retain null bytes in frontmatter, FAQ, or body content. Existing HTML used for interactive examples and formatting should remain intact.

## Changes

- Remove null bytes from expression and topic Markdown generation output.
- Add a manual `sanitize-posts` command that previews by default and writes only with `--write`.
- Add black-box tests confirming null bytes are removed while HTML and FAQ output are preserved.
