### PR TITLE
🐛 SSR 링크 노출 개수 확대

### DIFF
--- a/src/components/postGrid/postGrid.tsx
+++ b/src/components/postGrid/postGrid.tsx
@@ -18,7 +18,7 @@ const PostGrid: React.FC<PostGridProperties> = ({ posts }) => {
   const currentList = useInfiniteScroll({
     posts,
     scrollEdgeRef: scrollEdgeReference,
-    maxPostNum: 10,
+    maxPostNum: 24,
     offsetY: 200,
   })
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import { createPostItemListJsonLd } from "~/src/utils/structuredData"
 
 import { VERTICAL_AD_SLOT } from "../constants"
 
-const STRUCTURED_POST_LIST_LIMIT = 10
+const STRUCTURED_POST_LIST_LIMIT = 24
 
 const Home = ({
   pageContext,


### PR DESCRIPTION
## Why

Home and category pages only exposed the first 10 post links in SSR output and ItemList structured data.

## Changes

- Increase the initial SSR post grid count from 10 to 24.
- Increase home/category ItemList structured data entries from 10 to 24.
