### PR TITLE
♻️ SEO 확인용 root 설정 복원

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,7 +12,7 @@ const siteMetadata = {
   gtagTrackingId: meta.gtagTrackingId,
   googleAdsense: meta.googleAdsense,
   naverSiteVerification: meta.naverSiteVerification,
-  postTitle: "패턴으로 배우는 실전 영어 표현",
+  postTitle: "전체",
   menuLinks: [
     {
       link: "/",

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -84,7 +84,7 @@ const SEO: React.FC<SEOProperties> = ({
           url: `${site.siteUrl}${defaultOpenGraphImage}`,
         },
         description:
-          "영어 패턴 학습으로 자연스러운 영어 실력 향상을 돕는 학습 콘텐츠",
+          "영어 패턴 학습으로 자연스러운 영어 실력 향상을 돕는 교육 사이트",
         sameAs: ["https://github.com/engple"],
       } as EducationalOrganization,
       {
@@ -112,6 +112,7 @@ const SEO: React.FC<SEOProperties> = ({
     <Helmet
       htmlAttributes={{ lang: site.lang ?? DEFAULT_LANG }}
       title={displayTitle}
+      titleTemplate={displayTitle.replace(" 🍎", "")}
       meta={
         [
           {
@@ -123,12 +124,8 @@ const SEO: React.FC<SEOProperties> = ({
             content: description?.slice(0, 160),
           },
           {
-            name: "naver-site-verification",
+            property: "naver-site-verification",
             content: site.naverSiteVerification,
-          },
-          {
-            property: "og:locale",
-            content: (site.lang ?? DEFAULT_LANG).replace("-", "_"),
           },
           {
             property: "og:description",
@@ -141,10 +138,6 @@ const SEO: React.FC<SEOProperties> = ({
           {
             property: "og:title",
             content: displayTitle,
-          },
-          {
-            property: "og:site_name",
-            content: site.title,
           },
           {
             property: "og:type",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React, { useLayoutEffect, useMemo, useState } from "react"
 
 import { Link, type PageProps, graphql } from "gatsby"
 import kebabCase from "lodash/kebabCase"
@@ -9,17 +9,18 @@ import PostGrid from "~/src/components/postGrid"
 import SEO from "~/src/components/seo"
 import useSiteMetadata from "~/src/hooks/useSiteMetadata"
 import Layout from "~/src/layouts/layout"
+import type Post from "~/src/types/Post"
 import { createPostItemListJsonLd } from "~/src/utils/structuredData"
 
 import { VERTICAL_AD_SLOT } from "../constants"
 
-const STRUCTURED_POST_LIST_LIMIT = 24
-const HERO_DESCRIPTION_SEGMENT_LENGTH = 30
+const STRUCTURED_POST_LIST_LIMIT = 10
 
 const Home = ({
   pageContext,
   data,
 }: PageProps<Queries.Query, Queries.MarkdownRemarkFrontmatter>) => {
+  const [posts, setPosts] = useState<Post[]>([])
   const currentCategory = pageContext.category
   const postData = data.allMarkdownRemark.edges
   const visiblePostData = useMemo(() => {
@@ -34,32 +35,30 @@ const Home = ({
       .filter(group => group.fieldValue)
       .sort((first, second) => second.totalCount - first.totalCount)
   }, [data.allMarkdownRemark.group])
+  useLayoutEffect(() => {
+    setPosts(
+      visiblePostData.map(({ node }) => {
+        const { id, fields, frontmatter } = node
+        const { slug } = fields!
+        const { title, desc, date, category, thumbnail, alt } = frontmatter!
+        const { childImageSharp } = thumbnail!
 
-  const posts = useMemo(() => {
-    return visiblePostData.map(({ node }) => {
-      const { id, fields, frontmatter } = node
-      const { slug } = fields!
-      const { title, desc, date, category, thumbnail, alt } = frontmatter!
-      const { childImageSharp } = thumbnail!
-
-      return {
-        id,
-        slug,
-        title,
-        desc,
-        date,
-        category,
-        thumbnail: childImageSharp?.id,
-        alt,
-      }
-    })
+        return {
+          id,
+          slug,
+          title,
+          desc,
+          date,
+          category,
+          thumbnail: childImageSharp?.id,
+          alt,
+        }
+      }),
+    )
   }, [visiblePostData])
 
   const site = useSiteMetadata()
   const postTitle = currentCategory || site.postTitle
-  const heroDescription = currentCategory
-    ? `${postTitle} 카테고리의 영어 표현과 학습 글을 최신순으로 확인해보세요.`
-    : site.description
   const pagePath = currentCategory
     ? `/category/${kebabCase(currentCategory)}/`
     : "/"
@@ -104,41 +103,30 @@ const Home = ({
           />
         </LeftAd>
         <Content>
-          <HeroSection aria-labelledby="home-heading">
+          <HeroSection>
             <HeroCopy>
               <HeroEyebrow>
                 {currentCategory ? "Category Archive" : "Explore Engple"}
               </HeroEyebrow>
-              <PostTitle id="home-heading">{postTitle}</PostTitle>
-              <HeroDescription>
-                <SafeDescriptionText text={heroDescription} />
-              </HeroDescription>
+              <PostTitle>{postTitle}</PostTitle>
             </HeroCopy>
-            <CategorySection aria-labelledby="category-heading">
-              <SectionHeading id="category-heading">카테고리</SectionHeading>
-              <CategoryShelf>
-                <CategoryPill $isActive={!currentCategory} to="/">
-                  전체
+            <CategoryShelf aria-label="카테고리 탐색">
+              <CategoryPill $isActive={!currentCategory} to="/">
+                전체
+              </CategoryPill>
+              {categoryGroups.map(group => (
+                <CategoryPill
+                  key={group.fieldValue}
+                  $isActive={group.fieldValue === currentCategory}
+                  to={`/category/${kebabCase(group.fieldValue ?? "")}/`}
+                >
+                  <span>{group.fieldValue}</span>
+                  <CategoryCount>{group.totalCount}</CategoryCount>
                 </CategoryPill>
-                {categoryGroups.map(group => (
-                  <CategoryPill
-                    key={group.fieldValue}
-                    $isActive={group.fieldValue === currentCategory}
-                    to={`/category/${kebabCase(group.fieldValue ?? "")}/`}
-                  >
-                    <span>{group.fieldValue}</span>
-                    <CategoryCount>{group.totalCount}</CategoryCount>
-                  </CategoryPill>
-                ))}
-              </CategoryShelf>
-            </CategorySection>
+              ))}
+            </CategoryShelf>
           </HeroSection>
-          <PostListSection aria-labelledby="post-list-heading">
-            <SectionHeading id="post-list-heading">
-              {currentCategory ? `${postTitle} 최신 글` : "최신 영어 표현 글"}
-            </SectionHeading>
-            <PostGrid posts={posts} />
-          </PostListSection>
+          <PostGrid posts={posts} />
         </Content>
         <RightAd>
           <Adsense
@@ -155,35 +143,6 @@ const Home = ({
     </Layout>
   )
 }
-
-const SafeDescriptionText = ({ text }: { text?: string | null }) => {
-  return (
-    <>
-      {splitSafeDescriptionText(text).map((segment, index) => (
-        <span key={index}>{segment}</span>
-      ))}
-    </>
-  )
-}
-
-const splitSafeDescriptionText = (text?: string | null) => {
-  const characters = [...removeNullBytes(text ?? "")]
-  const segments: string[] = []
-
-  for (
-    let index = 0;
-    index < characters.length;
-    index += HERO_DESCRIPTION_SEGMENT_LENGTH
-  ) {
-    segments.push(
-      characters.slice(index, index + HERO_DESCRIPTION_SEGMENT_LENGTH).join(""),
-    )
-  }
-
-  return segments
-}
-
-const removeNullBytes = (text: string) => text.replaceAll("\u0000", "")
 
 const Main = styled.main`
   min-width: var(--min-width);
@@ -236,38 +195,10 @@ const PostTitle = styled.h1`
   }
 `
 
-const HeroDescription = styled.p`
-  max-width: 40rem;
-  margin-top: 10px;
-  color: var(--color-text-2);
-  font-size: 1rem;
-  line-height: 1.7;
-`
-
-const CategorySection = styled.section`
-  display: flex;
-  flex-direction: column;
-  gap: var(--sizing-sm);
-`
-
-const SectionHeading = styled.h2`
-  margin-bottom: 0;
-  color: var(--color-text);
-  font-size: 1.125rem;
-  font-weight: var(--font-weight-bold);
-  line-height: 1.3;
-`
-
 const CategoryShelf = styled.nav`
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-`
-
-const PostListSection = styled.section`
-  display: flex;
-  flex-direction: column;
-  gap: var(--sizing-md);
 `
 
 const CategoryPill = styled(Link)<{ $isActive: boolean }>`

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -29,7 +29,6 @@ import {
   withInlineAdsense,
 } from "../utils/adsense"
 import {
-  createAboutThingJsonLd,
   createDefinedTermJsonLd,
   createPracticeQuizJsonLd,
   getExpressionTerm,
@@ -121,10 +120,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
         ]
       : headings
   const compactTocHeadings = tocHeadings.filter(heading => heading.depth === 2)
-  const hideLeadVisualOnDesktop = startsWithHeroImage(
-    html,
-    ogImagePath ?? undefined,
-  )
+  const hideLeadVisualOnDesktop = startsWithHeroImage(html, ogImagePath)
 
   const featureImageAlt = alt || title || ""
 
@@ -220,14 +216,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
     isAccessibleForFree: true,
     teaches: title,
     assesses: title,
-    ...(expression
-      ? {
-          about: createAboutThingJsonLd({
-            id: definedTermId,
-            name: expression,
-          }),
-        }
-      : {}),
+    ...(expression ? { about: { "@id": definedTermId } } : {}),
     audience: {
       "@type": "EducationalAudience",
       educationalRole: "student",

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -153,10 +153,9 @@ export function createPracticeQuizJsonLd({
     "@type": "Quiz",
     "@id": id,
     name: `${title} 연습 문제`,
-    about: createAboutThingJsonLd({
-      id: aboutId,
-      name: expression || title,
-    }),
+    about: aboutId
+      ? { "@id": aboutId }
+      : { "@type": "Thing", name: expression },
     educationalAlignment: {
       "@type": "AlignmentObject",
       alignmentType: "educationalSubject",
@@ -164,25 +163,6 @@ export function createPracticeQuizJsonLd({
     },
     hasPart: cards.map(card => createPracticeQuestion(card)),
   } as Quiz
-}
-
-export function createAboutThingJsonLd({
-  id,
-  name,
-}: {
-  id?: string
-  name: string
-}) {
-  return id
-    ? {
-        "@type": "DefinedTerm",
-        "@id": id,
-        name,
-      }
-    : {
-        "@type": "Thing",
-        name,
-      }
 }
 
 function getPracticeCards(html: string) {


### PR DESCRIPTION
## Why

Naver SEO did not recover after null byte cleanup, so this narrows the next experiment to the previously working root/home and SEO metadata configuration.

## Changes

- Restore `gatsby-config.js` root post title from the known-good commit before `ddf1f394`.
- Restore `src/pages/index.tsx` root/home page implementation from that same known-good commit.
- Restore `src/components/seo.tsx`, `src/utils/structuredData.ts`, and SEO-related `src/templates/blogPost.tsx` structured data wiring from the known-good commit.
- Keep posts unchanged. `gatsby-node.js` matched the known-good version already, so it has no diff.

## Validation

- `yarn lint`
- `yarn lint:fix gatsby-config.js src/pages/index.tsx`
- `yarn lint:fix src/components/seo.tsx src/templates/blogPost.tsx src/utils/structuredData.ts`
- `git diff --check`
