### PR TITLE
🐛 Gatsby 산출물 null byte 제거

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -94,25 +94,16 @@ const createSearchPage = ({ createPage }) => {
 }
 
 exports.onPostBuild = async ({ reporter }) => {
-  const result = await removeNullBytesFromPublicFiles(path.resolve("public"))
+  const changedFiles = await removeNullBytesFromPublicFiles(
+    path.resolve("public"),
+  )
 
-  if (result.changedFiles > 0) {
-    reporter.info(
-      `Removed null bytes from ${result.changedFiles} generated file(s).`,
-    )
+  if (changedFiles > 0) {
+    reporter.info(`Removed null bytes from ${changedFiles} generated file(s).`)
   }
 }
 
 async function removeNullBytesFromPublicFiles(root) {
-  const files = await collectGeneratedTextFiles(root)
-  const results = await Promise.all(files.map(removeNullBytesFromFile))
-
-  return {
-    changedFiles: results.filter(Boolean).length,
-  }
-}
-
-async function collectGeneratedTextFiles(root) {
   let entries
 
   try {
@@ -122,37 +113,31 @@ async function collectGeneratedTextFiles(root) {
     throw error
   }
 
-  const nestedFiles = await Promise.all(
-    entries.map(entry => collectGeneratedTextFilesFromEntry(root, entry)),
+  const results = await Promise.all(
+    entries.map(async entry => {
+      const entryPath = path.join(root, entry.name)
+
+      if (entry.isDirectory()) {
+        return removeNullBytesFromPublicFiles(entryPath)
+      }
+
+      if (
+        !entry.isFile() ||
+        !NULL_BYTE_TEXT_EXTENSIONS.has(path.extname(entry.name))
+      ) {
+        return 0
+      }
+
+      const original = await fs.readFile(entryPath, "utf8")
+
+      if (!original.includes(NULL_BYTE)) {
+        return 0
+      }
+
+      await fs.writeFile(entryPath, original.replaceAll(NULL_BYTE, ""), "utf8")
+      return 1
+    }),
   )
 
-  return nestedFiles.flat()
-}
-
-async function collectGeneratedTextFilesFromEntry(root, entry) {
-  const entryPath = path.join(root, entry.name)
-
-  if (entry.isDirectory()) {
-    return collectGeneratedTextFiles(entryPath)
-  }
-
-  if (
-    !entry.isFile() ||
-    !NULL_BYTE_TEXT_EXTENSIONS.has(path.extname(entry.name))
-  ) {
-    return []
-  }
-
-  return [entryPath]
-}
-
-async function removeNullBytesFromFile(filePath) {
-  const original = await fs.readFile(filePath, "utf8")
-
-  if (!original.includes(NULL_BYTE)) {
-    return false
-  }
-
-  await fs.writeFile(filePath, original.replaceAll(NULL_BYTE, ""), "utf8")
-  return true
+  return results.reduce((total, count) => total + count, 0)
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,10 @@
 const path = require(`path`)
+const fs = require("fs/promises")
 const _ = require("lodash")
 const { createFilePath } = require(`gatsby-source-filesystem`)
+
+const NULL_BYTE = "\u0000"
+const NULL_BYTE_TEXT_EXTENSIONS = new Set([".html", ".json", ".xml"])
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions
@@ -87,4 +91,68 @@ const createSearchPage = ({ createPage }) => {
     component: searchTemplate,
     context: {},
   })
+}
+
+exports.onPostBuild = async ({ reporter }) => {
+  const result = await removeNullBytesFromPublicFiles(path.resolve("public"))
+
+  if (result.changedFiles > 0) {
+    reporter.info(
+      `Removed null bytes from ${result.changedFiles} generated file(s).`,
+    )
+  }
+}
+
+async function removeNullBytesFromPublicFiles(root) {
+  const files = await collectGeneratedTextFiles(root)
+  const results = await Promise.all(files.map(removeNullBytesFromFile))
+
+  return {
+    changedFiles: results.filter(Boolean).length,
+  }
+}
+
+async function collectGeneratedTextFiles(root) {
+  let entries
+
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true })
+  } catch (error) {
+    if (error.code === "ENOENT") return []
+    throw error
+  }
+
+  const nestedFiles = await Promise.all(
+    entries.map(entry => collectGeneratedTextFilesFromEntry(root, entry)),
+  )
+
+  return nestedFiles.flat()
+}
+
+async function collectGeneratedTextFilesFromEntry(root, entry) {
+  const entryPath = path.join(root, entry.name)
+
+  if (entry.isDirectory()) {
+    return collectGeneratedTextFiles(entryPath)
+  }
+
+  if (
+    !entry.isFile() ||
+    !NULL_BYTE_TEXT_EXTENSIONS.has(path.extname(entry.name))
+  ) {
+    return []
+  }
+
+  return [entryPath]
+}
+
+async function removeNullBytesFromFile(filePath) {
+  const original = await fs.readFile(filePath, "utf8")
+
+  if (!original.includes(NULL_BYTE)) {
+    return false
+  }
+
+  await fs.writeFile(filePath, original.replaceAll(NULL_BYTE, ""), "utf8")
+  return true
 }


### PR DESCRIPTION
## Why

Live post HTML still contains null bytes even though Markdown sources are clean, which points to generated Gatsby output. Search crawlers can see those bytes in breadcrumb and FAQ text.

## Changes

- Add `onPostBuild` cleanup that removes null bytes from generated `public` HTML, JSON, and XML files.
- Leave binary assets untouched.

## Validation

- `yarn lint`
- `git diff --check`
- Manual `onPostBuild` check confirmed null bytes are removed from generated `.html`/`.json` while `.png` remains unchanged.
