### PR TITLE
🐛 검색 페이지 SEO 메타 보강

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -16,20 +16,15 @@ import defaultOpenGraphImage from "../images/og-thumbnail.png"
 
 const DEFAULT_LANG = "en-US"
 
-type Meta = React.DetailedHTMLProps<
-  React.MetaHTMLAttributes<HTMLMetaElement>,
-  HTMLMetaElement
->[]
-
 interface SEOProperties {
   title?: Queries.Maybe<string>
   desc?: Queries.Maybe<string>
   image?: Queries.Maybe<string>
-  meta?: Meta
   jsonLds?: Thing[]
   url?: Queries.Maybe<string>
   ogType?: "website" | "article"
   noIndex?: boolean
+  noFollow?: boolean
   pageType?: "WebPage" | "CollectionPage"
   mainEntityId?: string
 }
@@ -42,18 +37,25 @@ const SEO: React.FC<SEOProperties> = ({
   jsonLds = [],
   ogType = "website",
   noIndex = false,
+  noFollow = false,
   pageType = "WebPage",
   mainEntityId,
 }) => {
   const site = useSiteMetadata()
+  const siteUrl = site.siteUrl || ""
+  const author = site.author || ""
+  const naverSiteVerification = site.naverSiteVerification || ""
   const displayTitle = title || site.title || ""
   const description = desc || site.description || ""
   const canonicalUrl = url || undefined
-  const pageUrl = canonicalUrl || site.siteUrl || ""
+  const pageUrl = canonicalUrl || siteUrl
   const ogImageUrl = getAbsoluteUrl(
     image || (defaultOpenGraphImage as string),
-    site.siteUrl || "",
+    siteUrl,
   )
+  const robotsContent = noIndex
+    ? `noindex,${noFollow ? "nofollow" : "follow"}`
+    : undefined
   const webPageJsonLd = canonicalUrl
     ? [
         createWebPageJsonLd({
@@ -62,7 +64,7 @@ const SEO: React.FC<SEOProperties> = ({
           language: site.lang ?? DEFAULT_LANG,
           mainEntityId,
           pageType,
-          siteUrl: site.siteUrl || "",
+          siteUrl,
           title: displayTitle,
           url: pageUrl,
         }),
@@ -75,13 +77,13 @@ const SEO: React.FC<SEOProperties> = ({
       ...jsonLds,
       {
         "@type": "EducationalOrganization",
-        "@id": `${site.siteUrl}/#organization`,
+        "@id": `${siteUrl}/#organization`,
         name: "잉플",
         alternateName: "Engple",
-        url: site.siteUrl,
+        url: siteUrl,
         logo: {
           "@type": "ImageObject",
-          url: `${site.siteUrl}${defaultOpenGraphImage}`,
+          url: `${siteUrl}${defaultOpenGraphImage}`,
         },
         description:
           "영어 패턴 학습으로 자연스러운 영어 실력 향상을 돕는 교육 사이트",
@@ -89,18 +91,18 @@ const SEO: React.FC<SEOProperties> = ({
       } as EducationalOrganization,
       {
         "@type": "WebSite",
-        "@id": `${site.siteUrl}/#website`,
+        "@id": `${siteUrl}/#website`,
         name: site.title,
         alternateName: "Engple",
-        url: site.siteUrl,
+        url: siteUrl,
         description: site.description,
         inLanguage: site.lang ?? DEFAULT_LANG,
-        publisher: { "@id": `${site.siteUrl}/#organization` },
+        publisher: { "@id": `${siteUrl}/#organization` },
         potentialAction: {
           "@type": "SearchAction",
           target: {
             "@type": "EntryPoint",
-            urlTemplate: `${site.siteUrl}/search?q={search_term_string}`,
+            urlTemplate: `${siteUrl}/search?q={search_term_string}`,
           },
           "query-input": "required name=search_term_string",
         },
@@ -113,66 +115,23 @@ const SEO: React.FC<SEOProperties> = ({
       htmlAttributes={{ lang: site.lang ?? DEFAULT_LANG }}
       title={displayTitle}
       titleTemplate={displayTitle.replace(" 🍎", "")}
-      meta={
-        [
-          {
-            property: "image",
-            content: ogImageUrl,
-          },
-          {
-            name: "description",
-            content: description?.slice(0, 160),
-          },
-          {
-            property: "naver-site-verification",
-            content: site.naverSiteVerification,
-          },
-          {
-            property: "og:description",
-            content: description,
-          },
-          {
-            property: "og:image",
-            content: ogImageUrl,
-          },
-          {
-            property: "og:title",
-            content: displayTitle,
-          },
-          {
-            property: "og:type",
-            content: ogType,
-          },
-          {
-            property: "og:url",
-            content: url || site.siteUrl,
-          },
-          {
-            property: "twitter:image",
-            content: ogImageUrl,
-          },
-          {
-            name: "twitter:card",
-            content: "summary_large_image",
-          },
-          {
-            name: "twitter:creator",
-            content: site.author,
-          },
-          {
-            name: "twitter:description",
-            content: description,
-          },
-          {
-            name: "twitter:title",
-            content: displayTitle,
-          },
-        ] as Meta
-      }
     >
+      <meta property="image" content={ogImageUrl} />
+      <meta name="description" content={description.slice(0, 160)} />
+      <meta name="naver-site-verification" content={naverSiteVerification} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={ogImageUrl} />
+      <meta property="og:title" content={displayTitle} />
+      <meta property="og:type" content={ogType} />
+      <meta property="og:url" content={url || siteUrl} />
+      <meta name="twitter:image" content={ogImageUrl} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:creator" content={author} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:title" content={displayTitle} />
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
-      {noIndex && <meta name="robots" content="noindex,follow" />}
-      {noIndex && <meta name="googlebot" content="noindex,follow" />}
+      {robotsContent && <meta name="robots" content={robotsContent} />}
+      {robotsContent && <meta name="googlebot" content={robotsContent} />}
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
     </Helmet>
   )

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -174,6 +174,7 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
         }
         url={`${site.siteUrl}/search/`}
         noIndex
+        noFollow
       />
       <Main>
         <LeftAd>
@@ -199,74 +200,80 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
             </SearchMeta>
           </SearchHeader>
 
-          {searchQuery ? searchResults.length > 0 ? (
-            <>
-              {relatedSuggestionTitles.length > 0 && (
-                <SuggestionSection aria-labelledby="related-search-heading">
-                  <SuggestionHeading id="related-search-heading">
-                    비슷한 검색어
+          {searchQuery ? (
+            searchResults.length > 0 ? (
+              <>
+                {relatedSuggestionTitles.length > 0 && (
+                  <SuggestionSection aria-labelledby="related-search-heading">
+                    <SuggestionHeading id="related-search-heading">
+                      비슷한 검색어
+                    </SuggestionHeading>
+                    <SuggestionList>
+                      {relatedSuggestionTitles.map(title => (
+                        <SuggestionItem key={title}>
+                          <SuggestionLink
+                            rel="nofollow"
+                            to={`/search/?q=${encodeURIComponent(title)}`}
+                          >
+                            {title}
+                          </SuggestionLink>
+                        </SuggestionItem>
+                      ))}
+                    </SuggestionList>
+                  </SuggestionSection>
+                )}
+                <PostGrid posts={searchResults} />
+              </>
+            ) : (
+              <EmptyState>
+                <EmptyTitle>검색 결과가 없습니다</EmptyTitle>
+                <EmptyBody>
+                  다른 단어로 검색하거나 아래 추천 검색어를 시도해보세요.
+                </EmptyBody>
+                {(relatedSuggestionTitles.length > 0 ||
+                  fallbackSuggestionTitles.length > 0) && (
+                  <SuggestionSection aria-labelledby="search-suggestion-heading">
+                    <SuggestionHeading id="search-suggestion-heading">
+                      추천 검색어
+                    </SuggestionHeading>
+                    <SuggestionList>
+                      {(relatedSuggestionTitles.length > 0
+                        ? relatedSuggestionTitles
+                        : fallbackSuggestionTitles
+                      ).map(title => (
+                        <SuggestionItem key={title}>
+                          <SuggestionLink
+                            rel="nofollow"
+                            to={`/search/?q=${encodeURIComponent(title)}`}
+                          >
+                            {title}
+                          </SuggestionLink>
+                        </SuggestionItem>
+                      ))}
+                    </SuggestionList>
+                  </SuggestionSection>
+                )}
+                <RecommendationSection aria-labelledby="recommended-posts-heading">
+                  <SuggestionHeading id="recommended-posts-heading">
+                    최근 글
                   </SuggestionHeading>
-                  <SuggestionList>
-                    {relatedSuggestionTitles.map(title => (
-                      <SuggestionItem key={title}>
-                        <SuggestionLink
-                          to={`/search/?q=${encodeURIComponent(title)}`}
-                        >
-                          {title}
-                        </SuggestionLink>
-                      </SuggestionItem>
+                  <RecommendationList>
+                    {recommendedPosts.map(post => (
+                      <RecommendationItem key={post.id}>
+                        <RecommendationLink to={post.slug}>
+                          <RecommendationCategory>
+                            {post.category}
+                          </RecommendationCategory>
+                          <RecommendationTitle>
+                            {post.title}
+                          </RecommendationTitle>
+                        </RecommendationLink>
+                      </RecommendationItem>
                     ))}
-                  </SuggestionList>
-                </SuggestionSection>
-              )}
-              <PostGrid posts={searchResults} />
-            </>
-          ) : (
-            <EmptyState>
-              <EmptyTitle>검색 결과가 없습니다</EmptyTitle>
-              <EmptyBody>
-                다른 단어로 검색하거나 아래 추천 검색어를 시도해보세요.
-              </EmptyBody>
-              {(relatedSuggestionTitles.length > 0 ||
-                fallbackSuggestionTitles.length > 0) && (
-                <SuggestionSection aria-labelledby="search-suggestion-heading">
-                  <SuggestionHeading id="search-suggestion-heading">
-                    추천 검색어
-                  </SuggestionHeading>
-                  <SuggestionList>
-                    {(relatedSuggestionTitles.length > 0
-                      ? relatedSuggestionTitles
-                      : fallbackSuggestionTitles
-                    ).map(title => (
-                      <SuggestionItem key={title}>
-                        <SuggestionLink
-                          to={`/search/?q=${encodeURIComponent(title)}`}
-                        >
-                          {title}
-                        </SuggestionLink>
-                      </SuggestionItem>
-                    ))}
-                  </SuggestionList>
-                </SuggestionSection>
-              )}
-              <RecommendationSection aria-labelledby="recommended-posts-heading">
-                <SuggestionHeading id="recommended-posts-heading">
-                  최근 글
-                </SuggestionHeading>
-                <RecommendationList>
-                  {recommendedPosts.map(post => (
-                    <RecommendationItem key={post.id}>
-                      <RecommendationLink to={post.slug}>
-                        <RecommendationCategory>
-                          {post.category}
-                        </RecommendationCategory>
-                        <RecommendationTitle>{post.title}</RecommendationTitle>
-                      </RecommendationLink>
-                    </RecommendationItem>
-                  ))}
-                </RecommendationList>
-              </RecommendationSection>
-            </EmptyState>
+                  </RecommendationList>
+                </RecommendationSection>
+              </EmptyState>
+            )
           ) : (
             <EmptyState>
               <EmptyTitle>검색어를 입력해보세요</EmptyTitle>
@@ -282,6 +289,7 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
                     {fallbackSuggestionTitles.map(title => (
                       <SuggestionItem key={title}>
                         <SuggestionLink
+                          rel="nofollow"
                           to={`/search/?q=${encodeURIComponent(title)}`}
                         >
                           {title}

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -101,8 +101,8 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
 
   const ogImagePath =
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    thumbnail &&
-    thumbnail?.childImageSharp?.gatsbyImageData!.images!.fallback!.src
+    thumbnail?.childImageSharp?.gatsbyImageData!.images!.fallback!.src ??
+    undefined
 
   const description = desc || excerpt
   const faqItems = (faqs ?? []).filter(item => item?.question && item?.answer)
@@ -302,6 +302,7 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
                     {category} 전체 보기
                   </ExploreAction>
                   <ExploreAction
+                    rel="nofollow"
                     to={`/search/?q=${encodeURIComponent(exploreSearchTerm)}`}
                   >
                     이 표현 더 찾기


### PR DESCRIPTION
## Why

Naver Search Advisor is reporting missing meta descriptions and duplicate titles on search query URLs. Search pages are already excluded from indexing, but their crawlable HTML still needs complete SEO metadata and should not keep spreading query URLs.

## Changes

- Render shared SEO meta tags as Helmet children so description, Open Graph, Twitter, and Naver verification tags are included in SSR HTML consistently.
- Add `noFollow` support to `SEO` and apply `noindex,nofollow` to the search page.
- Add `rel="nofollow"` to internal search query links from the search page and post detail page.

## Validation

- `yarn lint`
- `yarn typecheck`
- `git diff --check`
- Started `yarn develop` successfully and stopped it after startup.

Note: local `yarn build` was attempted but stopped during Gatsby image processing after a long run; this repository's production build is handled by the Pages workflow after merge.
