### PR TITLE
🐛 글 상세 검색 CTA 제거

### DIFF
--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -111,7 +111,6 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
   const articleId = `${pageUrl}#article`
   const definedTermId = `${pageUrl}#definedterm`
   const expression = getExpressionTerm({ category, title, faqs })
-  const exploreSearchTerm = expression || title || ""
   const tocHeadings =
     faqItems.length > 0
       ? [
@@ -300,12 +299,6 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
                 <ExploreActions aria-label="탐색 바로가기">
                   <ExploreAction to={categoryPath}>
                     {category} 전체 보기
-                  </ExploreAction>
-                  <ExploreAction
-                    rel="nofollow"
-                    to={`/search/?q=${encodeURIComponent(exploreSearchTerm)}`}
-                  >
-                    이 표현 더 찾기
                   </ExploreAction>
                 </ExploreActions>
               </ContentHeader>


### PR DESCRIPTION
## Why

Post detail pages still expose a CTA that links crawlers into `/search/?q=...` URLs. Those search query pages are noindex, but reducing internal entry points helps prevent more search URLs from being discovered and reported.

## Changes

- Remove the `이 표현 더 찾기` CTA from the post detail header.
- Remove the now-unused `exploreSearchTerm` value.
- Keep the category navigation CTA intact.

## Validation

- `yarn lint`
- `yarn typecheck`
- `git diff --check`
