### PR TITLE
🔍 검색 메타 페이지 생성

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,7 @@ const path = require(`path`)
 const fs = require("fs/promises")
 const _ = require("lodash")
 const { createFilePath } = require(`gatsby-source-filesystem`)
+const meta = require("./gatsby-meta-config")
 
 const NULL_BYTE = "\u0000"
 const NULL_BYTE_TEXT_EXTENSIONS = new Set([".html", ".json", ".xml"])
@@ -86,6 +87,7 @@ const createPostPages = ({ result, createPage }) => {
 
 const createSearchPage = ({ createPage }) => {
   const searchTemplate = path.resolve(`./src/pages/search.tsx`)
+
   createPage({
     path: `/search`,
     component: searchTemplate,
@@ -93,14 +95,157 @@ const createSearchPage = ({ createPage }) => {
   })
 }
 
-exports.onPostBuild = async ({ reporter }) => {
+exports.onPostBuild = async ({ graphql, reporter }) => {
+  const searchMetaPageCount = await createSearchResultMetaPages({ graphql })
   const changedFiles = await removeNullBytesFromPublicFiles(
     path.resolve("public"),
   )
 
+  if (searchMetaPageCount > 0) {
+    reporter.info(`Created ${searchMetaPageCount} search meta page(s).`)
+  }
+
   if (changedFiles > 0) {
     reporter.info(`Removed null bytes from ${changedFiles} generated file(s).`)
   }
+}
+
+async function createSearchResultMetaPages({ graphql }) {
+  const result = await graphql(`
+    {
+      postsRemark: allMarkdownRemark(
+        filter: { fileAbsolutePath: { regex: "/(posts/blog)/" } }
+        sort: { frontmatter: { date: DESC } }
+        limit: 2000
+      ) {
+        edges {
+          node {
+            frontmatter {
+              title
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  if (result.errors) {
+    throw result.errors
+  }
+
+  const searchLabels = collectSearchLabels(result.data.postsRemark.edges)
+
+  await Promise.all(
+    searchLabels.map(async searchQuery => {
+      const htmlPath = path.join(
+        "public",
+        ...createSearchPagePath(searchQuery).split("/").filter(Boolean),
+        "index.html",
+      )
+
+      await fs.mkdir(path.dirname(htmlPath), { recursive: true })
+      await fs.writeFile(
+        htmlPath,
+        createSearchResultMetaPageHtml(searchQuery),
+        "utf8",
+      )
+    }),
+  )
+
+  return searchLabels.length
+}
+
+function collectSearchLabels(edges) {
+  const seenPaths = new Set()
+
+  return edges
+    .map(({ node }) => extractSearchSuggestionLabel(node.frontmatter?.title))
+    .filter(searchQuery => {
+      if (!searchQuery) return false
+
+      const searchPagePath = createSearchPagePath(searchQuery)
+
+      if (seenPaths.has(searchPagePath)) return false
+
+      seenPaths.add(searchPagePath)
+      return true
+    })
+}
+
+function extractSearchSuggestionLabel(title = "") {
+  const trimmedTitle = title.trim()
+  const quotedTermMatch = trimmedTitle.match(/^['"“‘]([^'"”’]+)['"”’]/u)
+
+  if (quotedTermMatch?.[1]) {
+    return quotedTermMatch[1].trim()
+  }
+
+  return trimmedTitle
+    .replace(/\s+영어로 어떻게 표현할까.*$/u, "")
+    .split(" - ")[0]
+    .trim()
+}
+
+function createSearchResultMetaPageHtml(searchQuery) {
+  const searchPagePath = createSearchPagePath(searchQuery)
+  const searchPageQueryPath = `/search/?q=${encodeURIComponent(searchQuery)}`
+  const canonicalUrl = `${meta.siteUrl}${searchPagePath}`
+  const title = `'${searchQuery}'에 대한 검색 결과 - ${meta.title}`
+  const description = `'${searchQuery}' 검색 결과와 추천 표현을 확인해보세요.`
+
+  return `<!doctype html>
+<html lang="${escapeAttribute(meta.lang)}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <meta name="description" content="${escapeAttribute(description.slice(0, 160))}">
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="googlebot" content="noindex,nofollow">
+  <meta property="og:title" content="${escapeAttribute(title)}">
+  <meta property="og:description" content="${escapeAttribute(description)}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="${escapeAttribute(canonicalUrl)}">
+  <meta name="twitter:title" content="${escapeAttribute(title)}">
+  <meta name="twitter:description" content="${escapeAttribute(description)}">
+  <link rel="canonical" href="${escapeAttribute(canonicalUrl)}">
+  <meta http-equiv="refresh" content="0; url=${escapeAttribute(searchPageQueryPath)}">
+</head>
+<body>
+  <main>
+    <h1>${escapeHtml(searchQuery)} 검색</h1>
+    <p><a href="${escapeAttribute(searchPageQueryPath)}">검색 결과 보기</a></p>
+  </main>
+  <script>window.location.replace(${JSON.stringify(searchPageQueryPath)});</script>
+</body>
+</html>
+`
+}
+
+function escapeHtml(value) {
+  return value.replaceAll(/[&<>"']/g, character => {
+    return HTML_ESCAPE_MAP[character]
+  })
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value)
+}
+
+const HTML_ESCAPE_MAP = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+}
+
+function createSearchPagePath(searchTerm) {
+  return `/search/${encodeURIComponent(normalizeSearchTerm(searchTerm))}/`
+}
+
+function normalizeSearchTerm(value) {
+  return value.trim().toLocaleLowerCase().replaceAll(/\s+/g, " ")
 }
 
 async function removeNullBytesFromPublicFiles(root) {

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -12,6 +12,7 @@ import Layout from "~/src/layouts/layout"
 import type Post from "~/src/types/Post"
 import {
   collectSearchSuggestionLabels,
+  createSearchPagePath,
   matchesSearchRecord,
 } from "~/src/utils/search"
 
@@ -54,18 +55,27 @@ interface SearchPageData {
   }
 }
 
+interface SearchPageContext {
+  searchQuery?: string
+}
+
 const SUGGESTION_LIMIT = 6
 const RECOMMENDATION_LIMIT = 4
 
-const SearchPage: React.FC<PageProps<SearchPageData>> = ({
+const SearchPage: React.FC<PageProps<SearchPageData, SearchPageContext>> = ({
   location,
+  pageContext,
   data,
 }) => {
   const headingRef = useRef<HTMLHeadingElement>(null)
   const site = useSiteMetadata()
   const searchQuery = useMemo(() => {
-    return new URLSearchParams(location.search).get("q")?.trim() ?? ""
-  }, [location.search])
+    return (
+      pageContext.searchQuery?.trim() ||
+      new URLSearchParams(location.search).get("q")?.trim() ||
+      ""
+    )
+  }, [location.search, pageContext.searchQuery])
   const directMatches = useMemo(() => {
     return (
       data.fusejs?.data.filter(item =>
@@ -154,6 +164,9 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
       }))
   }, [data.allMarkdownRemark.edges])
   const totalResultCount = searchResults.length
+  const searchPagePath = searchQuery
+    ? createSearchPagePath(searchQuery)
+    : "/search/"
 
   useEffect(() => {
     headingRef.current?.focus()
@@ -172,7 +185,7 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
             ? `'${searchQuery}' 검색 결과와 추천 표현을 확인해보세요.`
             : "영어 표현과 글을 검색해보세요."
         }
-        url={`${site.siteUrl}/search/`}
+        url={`${site.siteUrl}${searchPagePath}`}
         noIndex
         noFollow
       />
@@ -213,7 +226,7 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
                         <SuggestionItem key={title}>
                           <SuggestionLink
                             rel="nofollow"
-                            to={`/search/?q=${encodeURIComponent(title)}`}
+                            href={createSearchPagePath(title)}
                           >
                             {title}
                           </SuggestionLink>
@@ -244,7 +257,7 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
                         <SuggestionItem key={title}>
                           <SuggestionLink
                             rel="nofollow"
-                            to={`/search/?q=${encodeURIComponent(title)}`}
+                            href={createSearchPagePath(title)}
                           >
                             {title}
                           </SuggestionLink>
@@ -290,7 +303,7 @@ const SearchPage: React.FC<PageProps<SearchPageData>> = ({
                       <SuggestionItem key={title}>
                         <SuggestionLink
                           rel="nofollow"
-                          to={`/search/?q=${encodeURIComponent(title)}`}
+                          href={createSearchPagePath(title)}
                         >
                           {title}
                         </SuggestionLink>
@@ -384,7 +397,7 @@ const SuggestionItem = styled.li`
   margin: 0;
 `
 
-const SuggestionLink = styled(Link)`
+const SuggestionLink = styled.a`
   display: inline-flex;
   align-items: center;
   min-height: 2.25rem;

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -28,6 +28,7 @@ import {
   initializeInlineAdsenseSlots,
   withInlineAdsense,
 } from "../utils/adsense"
+import { createSearchPagePath } from "../utils/search"
 import {
   createDefinedTermJsonLd,
   createPracticeQuizJsonLd,
@@ -301,12 +302,12 @@ const BlogPost: React.FC<PageProps<DataProps>> = ({ data }) => {
                   <ExploreAction to={categoryPath}>
                     {category} 전체 보기
                   </ExploreAction>
-                  <ExploreAction
+                  <ExploreSearchAction
                     rel="nofollow"
-                    to={`/search/?q=${encodeURIComponent(exploreSearchTerm)}`}
+                    href={createSearchPagePath(exploreSearchTerm)}
                   >
                     이 표현 더 찾기
-                  </ExploreAction>
+                  </ExploreSearchAction>
                 </ExploreActions>
               </ContentHeader>
               <Divider />
@@ -487,10 +488,7 @@ const mapPostNodeToPost = ({
     ...frontmatter,
     desc: frontmatter.desc || undefined,
     slug: fields.slug,
-    thumbnail:
-      frontmatter.thumbnail?.publicURL ||
-      frontmatter.thumbnail?.childImageSharp?.gatsbyImageData?.images?.fallback
-        ?.src,
+    thumbnail: undefined,
   }
 }
 
@@ -634,6 +632,32 @@ const ExploreActions = styled.div`
 `
 
 const ExploreAction = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  padding: 0 16px;
+  border: 1px solid var(--color-gray-2);
+  border-radius: 999px;
+  background-color: var(--color-card);
+  color: var(--color-text-2);
+  font-size: 0.9375rem;
+  font-weight: var(--font-weight-semi-bold);
+  line-height: 1;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    color 0.2s ease;
+
+  &:hover {
+    color: var(--color-text);
+    border-color: var(--color-gray-3);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
+  }
+`
+
+const ExploreSearchAction = styled.a`
   display: inline-flex;
   align-items: center;
   min-height: 2.75rem;
@@ -1107,9 +1131,6 @@ export const query = graphql`
             date(formatString: "YYYY-MM-DD")
             category
             alt
-            thumbnail {
-              publicURL
-            }
           }
           fields {
             slug

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -56,3 +56,7 @@ export const collectSearchSuggestionLabels = (
     })
     .slice(0, limit)
 }
+
+export const createSearchPagePath = (searchTerm: string) => {
+  return `/search/${encodeURIComponent(normalizeSearchTerm(searchTerm))}/`
+}


### PR DESCRIPTION
## Why
검색어별 검색 진입 URL에서 서버가 생성한 title과 description이 동일하거나 일반 검색 페이지 메타로 보이는 문제를 줄입니다.

## Changes
- 빌드 후 `/search/<검색어>/index.html` 정적 메타 페이지를 생성해 검색어별 title/description을 서버 HTML에 포함합니다.
- 검색 추천 링크와 글 상세의 검색 링크를 정적 메타 페이지 경로로 연결하고, 해당 HTML에서 실제 `/search/?q=` 결과 페이지로 이동하게 했습니다.
- 상세 글 이어보기 목록에서 `thumbnail.publicURL` 대량 복사를 제거해 Gatsby 병렬 빌드의 publicURL 파일 복사 오류를 피합니다.

## Verification
- `node -c gatsby-node.js`
- `yarn eslint gatsby-node.js src/pages/search.tsx src/templates/blogPost.tsx src/utils/search.ts`
- fake GraphQL 데이터로 `onPostBuild` 실행 후 title과 description이 서로 다르게 생성되는지 확인
- `yarn build`는 여러 차례 시도했지만 이 저장소의 전체 Gatsby HTML 렌더링/이미지 처리 단계가 12분 이상 종료되지 않아 중단했습니다.
