### PR TITLE
🐛 이전글 다음글 추천 복원

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -181,7 +181,7 @@ const createPostPages = ({ result, createPage }) => {
       component: template,
       context: {
         slug: post.slug,
-        continuePosts: selectContinuePosts(posts, post.slug, post.category),
+        continuePosts: selectContinuePosts(posts, post.slug),
       },
     })
   })
@@ -197,40 +197,20 @@ function mapPostNodeToPost(node) {
   }
 }
 
-const RELATED_POST_LIMIT = 6
-
-function selectContinuePosts(posts, currentSlug, currentCategory) {
+function selectContinuePosts(posts, currentSlug) {
   const currentIndex = posts.findIndex(post => post.slug === currentSlug)
 
   if (currentIndex === -1) return []
 
-  const relatedPosts = currentCategory
-    ? posts
-        .filter(
-          (post, index) =>
-            index !== currentIndex && post.category === currentCategory,
-        )
-        .slice(0, RELATED_POST_LIMIT)
-        .map(post => ({ ...post, direction: "관련 글" }))
-    : []
-
-  if (relatedPosts.length >= RELATED_POST_LIMIT) return relatedPosts
-
-  const usedSlugs = new Set([
-    currentSlug,
-    ...relatedPosts.map(post => post.slug),
-  ])
-  const dateAdjacentPosts = [
+  return [
     ...posts
-      .slice(currentIndex + 1)
+      .slice(currentIndex + 1, currentIndex + 3)
       .map(post => ({ ...post, direction: "이전 글" })),
     ...posts
-      .slice(0, currentIndex)
+      .slice(Math.max(0, currentIndex - 2), currentIndex)
       .reverse()
       .map(post => ({ ...post, direction: "다음 글" })),
-  ].filter(post => !usedSlugs.has(post.slug))
-
-  return [...relatedPosts, ...dateAdjacentPosts].slice(0, RELATED_POST_LIMIT)
+  ]
 }
 
 function sortPostsForContinue(posts) {


### PR DESCRIPTION
## Why

- 글 하단 추천 영역이 기존 이전글/다음글 흐름 대신 같은 카테고리의 최신 글 6개를 보여주고 있었습니다.
- 현재 글 주변의 인접 글을 보여주는 기존 탐색 경험을 복원합니다.

## Changes

- 글 페이지 생성 시 `continuePosts`를 현재 글 기준 이전 2개, 다음 2개로 다시 계산합니다.
- 같은 카테고리 최신 글을 우선 노출하던 `관련 글` 선택 로직을 제거했습니다.
