### PR TITLE
✨ About 페이지와 교육용 구조화 데이터 보강

### DIFF
--- a/.github/scripts/indexnow-ping.js
+++ b/.github/scripts/indexnow-ping.js
@@ -7,7 +7,7 @@
 // that changed in this deploy, right after the site goes live.
 const { execSync } = require("child_process")
 
-const SITE_HOST = "engple.github.io"
+const SITE_HOST = "engple.solaqua.dev"
 const SITE_URL = `https://${SITE_HOST}`
 const INDEXNOW_KEY = "8741f96dfd427a60f4f080959aec0523"
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow"

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -184,8 +184,8 @@ const searchPlugins = [
   {
     resolve: "gatsby-plugin-robots-txt",
     options: {
-      host: "https://engple.github.io",
-      sitemap: "https://engple.github.io/sitemap-index.xml",
+      host: meta.siteUrl,
+      sitemap: `${meta.siteUrl}/sitemap-index.xml`,
       policy: [{ userAgent: "*", allow: "/" }],
     },
   },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,10 +18,10 @@ const siteMetadata = {
       link: "/",
       name: "Home",
     },
-    // {
-    //   link: "/about/",
-    //   name: "About",
-    // },
+    {
+      link: "/about/",
+      name: "About",
+    },
     // {
     //   link: meta.links.github,
     //   name: "Github",

--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -24,7 +24,7 @@ const metaConfig = {
   description:
     "잉플에서 실전 영어 표현과 영어 패턴을 한국어 예문으로 쉽게 익히세요. 발음, 상황별 예문, 연습 문제까지 한 번에 확인할 수 있습니다.",
   author: "solaqua",
-  siteUrl: "https://engple.github.io",
+  siteUrl: "https://engple.solaqua.dev",
   lang: "ko-KR",
   utterances: "",
   links: {

--- a/src/components/navBar/linkList.tsx
+++ b/src/components/navBar/linkList.tsx
@@ -9,7 +9,7 @@ import type { UseMenuReturnType } from "./useMenu"
 
 const ROOT = "/"
 const EXTERNAL_LINK_EXP =
-  /(https?:\/\/)?[\w~\-]+(\.[\w~\-]+)+(\/[\w%:@~\-]*)*(#[\w-]*)?(\?\S*)?/gi
+  /(https?:\/\/)?[\w~-]+(\.[\w~-]+)+(\/[\w%:@~-]*)*(#[\w-]*)?(\?\S*)?/i
 
 interface LinkListProperties extends Pick<UseMenuReturnType, "setToggle"> {
   links: UseSiteMetaDataReturnType["menuLinks"]
@@ -38,7 +38,7 @@ const LinkList: React.FC<LinkListProperties> = ({ links, setToggle }) => {
     if (isExternalLink) {
       return (
         <li key={name}>
-          <a target="__blank" rel="noreferrer" href={safeLink}>
+          <a target="_blank" rel="noreferrer" href={safeLink}>
             {name}
           </a>
         </li>
@@ -46,7 +46,9 @@ const LinkList: React.FC<LinkListProperties> = ({ links, setToggle }) => {
     }
     return (
       <li key={name}>
-        <Link to={safeLink}>{name}</Link>
+        <Link to={safeLink} onClick={() => setToggle(false)}>
+          {name}
+        </Link>
       </li>
     )
   }

--- a/src/components/navBar/linkList.tsx
+++ b/src/components/navBar/linkList.tsx
@@ -1,13 +1,11 @@
 import React from "react"
 
 import { Link } from "gatsby"
-import { isNil } from "lodash"
 
 import type { UseSiteMetaDataReturnType } from "~/src/hooks/useSiteMetadata"
 
 import type { UseMenuReturnType } from "./useMenu"
 
-const ROOT = "/"
 const EXTERNAL_LINK_EXP =
   /(https?:\/\/)?[\w~-]+(\.[\w~-]+)+(\/[\w%:@~-]*)*(#[\w-]*)?(\?\S*)?/i
 
@@ -19,22 +17,14 @@ const LinkList: React.FC<LinkListProperties> = ({ links, setToggle }) => {
   const generateLink = (
     properties: Queries.SiteSiteMetadataMenuLinks | null,
   ) => {
-    if (isNil(properties)) {
+    if (properties == null) {
       return
     }
 
     const { link, name } = properties
-    const safeLink = isNil(link) ? "" : link
+    const safeLink = link ?? ""
     const isExternalLink = EXTERNAL_LINK_EXP.test(safeLink)
-    if (safeLink === ROOT) {
-      return (
-        <li key={name}>
-          <Link to={safeLink} onClick={() => setToggle(false)}>
-            {name}
-          </Link>
-        </li>
-      )
-    }
+
     if (isExternalLink) {
       return (
         <li key={name}>

--- a/src/components/navBar/menuIcon.tsx
+++ b/src/components/navBar/menuIcon.tsx
@@ -4,12 +4,23 @@ import styled from "styled-components"
 
 import type { UseMenuReturnType } from "./useMenu"
 
-const MenuIcon: React.FC<Omit<UseMenuReturnType, "setToggle">> = ({
+interface MenuIconProperties extends Omit<UseMenuReturnType, "setToggle"> {
+  controlsId: string
+}
+
+const MenuIcon: React.FC<MenuIconProperties> = ({
+  controlsId,
   toggle,
   handleClick,
 }) => {
   return (
-    <MenuIconButton onClick={handleClick} toggle={toggle} aria-label="Menu">
+    <MenuIconButton
+      onClick={handleClick}
+      toggle={toggle}
+      aria-controls={controlsId}
+      aria-expanded={toggle}
+      aria-label="Menu"
+    >
       <MenuIconBreadTop>
         <div />
       </MenuIconBreadTop>

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -16,6 +16,8 @@ import SearchBar from "./searchBar"
 import SearchIcon from "./searchIcon"
 import useMenu, { type UseMenuReturnType } from "./useMenu"
 
+const MENU_LIST_ID = "global-navigation-menu"
+
 interface NavBarProperties {
   links: UseSiteMetaDataReturnType["menuLinks"]
   title?: string | null
@@ -59,12 +61,16 @@ const NavBar: React.FC<NavBarProperties> = ({ links, title }) => {
         <Title onClick={() => setToggle(false)}>
           <Link to="/">{title}</Link>
         </Title>
-        <List ref={listReference} toggle={toggle}>
+        <List id={MENU_LIST_ID} ref={listReference} toggle={toggle}>
           <LinkList links={links} setToggle={setToggle} />
         </List>
         <Curtain ref={curtainReference} toggle={toggle} />
         <IconWrapper>
-          <MenuIcon handleClick={handleClick} toggle={toggle} />
+          <MenuIcon
+            controlsId={MENU_LIST_ID}
+            handleClick={handleClick}
+            toggle={toggle}
+          />
           <SearchIcon
             buttonRef={searchTriggerReference}
             onClick={handleOpenSearch}

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -8,16 +8,20 @@ import {
   curtainAnimationCSS,
   navBackgroundAnimationCSS,
 } from "~/src/styles/navBarAnimation"
+import type { UseSiteMetaDataReturnType } from "~/src/hooks/useSiteMetadata"
 
+import LinkList from "./linkList"
+import MenuIcon from "./menuIcon"
 import SearchBar from "./searchBar"
 import SearchIcon from "./searchIcon"
 import useMenu, { type UseMenuReturnType } from "./useMenu"
 
 interface NavBarProperties {
+  links: UseSiteMetaDataReturnType["menuLinks"]
   title?: string | null
 }
 
-const NavBar: React.FC<NavBarProperties> = ({ title }) => {
+const NavBar: React.FC<NavBarProperties> = ({ links, title }) => {
   const { device } = useContext(ThemeContext)!
   const navReference = useRef<HTMLElement>(null)
   const curtainReference = useRef<HTMLDivElement>(null)
@@ -25,7 +29,7 @@ const NavBar: React.FC<NavBarProperties> = ({ title }) => {
   const searchTriggerReference = useRef<HTMLButtonElement>(null)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
 
-  const { toggle, setToggle } = useMenu({
+  const { handleClick, toggle, setToggle } = useMenu({
     navRef: navReference,
     curtainRef: curtainReference,
     listRef: listReference,
@@ -55,8 +59,12 @@ const NavBar: React.FC<NavBarProperties> = ({ title }) => {
         <Title onClick={() => setToggle(false)}>
           <Link to="/">{title}</Link>
         </Title>
+        <List ref={listReference} toggle={toggle}>
+          <LinkList links={links} setToggle={setToggle} />
+        </List>
         <Curtain ref={curtainReference} toggle={toggle} />
         <IconWrapper>
+          <MenuIcon handleClick={handleClick} toggle={toggle} />
           <SearchIcon
             buttonRef={searchTriggerReference}
             onClick={handleOpenSearch}
@@ -126,6 +134,53 @@ const Title = styled.div`
 
   @media (max-width: ${({ theme }) => theme.device.sm}) {
     font-size: var(--text-md);
+  }
+`
+
+const List = styled.ul<Toggleable>`
+  display: flex;
+  gap: var(--sizing-md);
+  align-items: center;
+  margin-left: auto;
+  margin-right: var(--sizing-base);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+
+  a {
+    color: var(--color-text-3);
+    transition: color 0.2s ease;
+  }
+
+  a:hover {
+    color: var(--color-text);
+  }
+
+  @media (max-width: ${({ theme }) => theme.device.sm}) {
+    position: fixed;
+    top: var(--nav-height);
+    left: 0;
+    z-index: 9998;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    height: calc(100vh - var(--nav-height));
+    box-sizing: border-box;
+    padding: var(--sizing-lg) var(--padding-lg);
+    margin: 0;
+    gap: var(--sizing-md);
+    background-color: var(--color-post-background);
+    opacity: ${({ toggle }) => (toggle ? 1 : 0)};
+    pointer-events: ${({ toggle }) => (toggle ? "auto" : "none")};
+    transform: translateY(${({ toggle }) => (toggle ? "0" : "-8px")});
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s ease;
+
+    a {
+      display: block;
+      font-size: var(--text-lg);
+      color: var(--color-text);
+    }
   }
 `
 

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -2,9 +2,11 @@ import React from "react"
 
 import { Helmet } from "react-helmet"
 import {
+  type AboutPage,
   type CollectionPage,
   type EducationalOrganization,
   type Graph,
+  type Person,
   type Thing,
   type WebPage,
   type WebSite,
@@ -33,7 +35,7 @@ interface SEOProperties {
   ogType?: "website" | "article"
   noIndex?: boolean
   noFollow?: boolean
-  pageType?: "WebPage" | "CollectionPage"
+  pageType?: "WebPage" | "CollectionPage" | "AboutPage"
   mainEntityId?: string
   publishedTime?: Queries.Maybe<string>
   modifiedTime?: Queries.Maybe<string>
@@ -60,6 +62,9 @@ const SEO: React.FC<SEOProperties> = ({
 }) => {
   const site = useSiteMetadata()
   const siteUrl = site.siteUrl || ""
+  const aboutUrl = `${siteUrl}/about/`
+  const organizationId = `${aboutUrl}#organization`
+  const personId = `${aboutUrl}#person`
   const author = site.author || ""
   const naverSiteVerification = site.naverSiteVerification || ""
   const hasCustomTitle = Boolean(title)
@@ -105,10 +110,11 @@ const SEO: React.FC<SEOProperties> = ({
       ...jsonLds,
       {
         "@type": "EducationalOrganization",
-        "@id": `${siteUrl}/#organization`,
+        "@id": organizationId,
         name: "잉플",
         alternateName: "Engple",
         url: siteUrl,
+        mainEntityOfPage: { "@id": `${aboutUrl}#webpage` },
         logo: {
           "@type": "ImageObject",
           url: `${siteUrl}${defaultOpenGraphImage}`,
@@ -116,7 +122,20 @@ const SEO: React.FC<SEOProperties> = ({
         description:
           "영어 패턴 학습으로 자연스러운 영어 실력 향상을 돕는 교육 사이트",
         sameAs: ["https://github.com/engple"],
+        founder: { "@id": personId },
       } as EducationalOrganization,
+      {
+        "@type": "Person",
+        "@id": personId,
+        name: author || "solaqua",
+        url: aboutUrl,
+        affiliation: { "@id": organizationId },
+        knowsAbout: [
+          "English language learning",
+          "Korean explanations for English expressions",
+          "Example-based vocabulary learning",
+        ],
+      } as Person,
       {
         "@type": "WebSite",
         "@id": `${siteUrl}/#website`,
@@ -125,7 +144,7 @@ const SEO: React.FC<SEOProperties> = ({
         url: siteUrl,
         description: site.description,
         inLanguage: site.lang ?? DEFAULT_LANG,
-        publisher: { "@id": `${siteUrl}/#organization` },
+        publisher: { "@id": organizationId },
         potentialAction: {
           "@type": "SearchAction",
           target: {
@@ -205,7 +224,7 @@ function createWebPageJsonLd({
   imageUrl: string
   language: string
   mainEntityId?: string
-  pageType: "WebPage" | "CollectionPage"
+  pageType: "WebPage" | "CollectionPage" | "AboutPage"
   siteUrl: string
   title: string
   url: string
@@ -218,7 +237,7 @@ function createWebPageJsonLd({
     url,
     inLanguage: language,
     isPartOf: { "@id": `${siteUrl}/#website` },
-    publisher: { "@id": `${siteUrl}/#organization` },
+    publisher: { "@id": `${siteUrl}/about/#organization` },
     primaryImageOfPage: {
       "@type": "ImageObject",
       url: imageUrl,
@@ -226,7 +245,7 @@ function createWebPageJsonLd({
     ...(mainEntityId ? { mainEntity: { "@id": mainEntityId } } : {}),
   }
 
-  return pageJsonLd as CollectionPage | WebPage
+  return pageJsonLd as AboutPage | CollectionPage | WebPage
 }
 
 function truncateDescription(text: string, maxLength: number) {

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -13,7 +13,7 @@ import ThemeToggleButton from "../components/navBar/themeToggleButton"
 
 const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { theme, themeToggler } = useTheme()
-  const { title } = useSiteMetadata()
+  const { menuLinks, title } = useSiteMetadata()
   const copyrightString = `Copyright © engple 2024`
 
   return (
@@ -21,7 +21,7 @@ const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
       <ThemeContext.Provider value={theme}>
         <GlobalStyle />
         <Container>
-          <NavBar title={title} />
+          <NavBar links={menuLinks} title={title} />
           {children}
         </Container>
         <Footer role="contentinfo">

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,0 +1,170 @@
+import React from "react"
+
+import { Link } from "gatsby"
+import styled from "styled-components"
+
+import SEO from "~/src/components/seo"
+import useSiteMetadata from "~/src/hooks/useSiteMetadata"
+import Layout from "~/src/layouts/layout"
+
+const ABOUT_TITLE = "About"
+const ABOUT_DESCRIPTION =
+  "잉플은 한국어 사용자가 영어 표현과 패턴을 실제 예문으로 익힐 수 있도록 정리하는 영어 학습 사이트입니다."
+
+const AboutPageTemplate = () => {
+  const site = useSiteMetadata()
+  const siteUrl = site.siteUrl || ""
+  const pageUrl = `${siteUrl}/about/`
+  const organizationId = `${siteUrl}/about/#organization`
+
+  return (
+    <Layout>
+      <SEO
+        title={ABOUT_TITLE}
+        desc={ABOUT_DESCRIPTION}
+        url={pageUrl}
+        pageType="AboutPage"
+        mainEntityId={organizationId}
+      />
+      <Main>
+        <Content>
+          <Header>
+            <Eyebrow>About Engple</Eyebrow>
+            <Title>잉플은 영어 표현을 예문 중심으로 정리합니다.</Title>
+            <Lead>{ABOUT_DESCRIPTION}</Lead>
+          </Header>
+
+          <Section>
+            <SectionTitle>운영 주체</SectionTitle>
+            <Paragraph>
+              잉플은 solaqua가 운영하는 개인 영어 학습 프로젝트입니다. 사이트의
+              목표는 한국어 사용자가 영어 표현을 검색하고, 문맥 안에서 이해하고,
+              직접 말해볼 수 있도록 짧고 반복 가능한 학습 자료를 제공하는
+              것입니다.
+            </Paragraph>
+            <Paragraph>
+              개발과 콘텐츠 관리 이력은{" "}
+              <ExternalLink href="https://github.com/engple" rel="noreferrer">
+                GitHub의 Engple 조직
+              </ExternalLink>
+              에서 확인할 수 있습니다.
+            </Paragraph>
+          </Section>
+
+          <Section>
+            <SectionTitle>콘텐츠 제작 방식</SectionTitle>
+            <Paragraph>
+              각 글은 하나의 영어 표현, 패턴, 어휘, 또는 주제를 중심으로
+              구성됩니다. 한국어 설명, 영어 예문, 발음 정보, 연습 카드, 관련
+              표현을 함께 배치해 학습자가 같은 표현을 여러 상황에서 확인할 수
+              있게 합니다.
+            </Paragraph>
+            <Paragraph>
+              일부 초안 작성과 예문 후보 수집에는 자동화 도구를 사용합니다. 게시
+              전에는 표현의 자연스러움, 한국어 설명의 정확성, 내부 링크, 중복
+              여부를 점검하며, 발견한 오류는 이후 수정합니다.
+            </Paragraph>
+          </Section>
+
+          <Section>
+            <SectionTitle>수정과 문의</SectionTitle>
+            <Paragraph>
+              영어 표현은 맥락과 지역에 따라 자연스러움이 달라질 수 있습니다.
+              부정확한 번역, 어색한 예문, 깨진 링크, 저작권 또는 기타 문의가
+              있으면{" "}
+              <ExternalLink
+                href="https://github.com/engple/engple.github.io/issues"
+                rel="noreferrer"
+              >
+                GitHub Issues
+              </ExternalLink>
+              를 통해 알려주세요.
+            </Paragraph>
+            <ActionLink to="/">최근 학습 글 보기</ActionLink>
+          </Section>
+        </Content>
+      </Main>
+    </Layout>
+  )
+}
+
+const Main = styled.main`
+  min-width: var(--min-width);
+  min-height: calc(100vh - var(--nav-height) - var(--footer-height));
+  background-color: var(--color-post-background);
+`
+
+const Content = styled.div`
+  width: 87.5%;
+  max-width: var(--post-width);
+  margin: 0 auto;
+  padding: var(--sizing-xl) 0 var(--sizing-xxl);
+`
+
+const Header = styled.header`
+  margin-bottom: var(--sizing-xl);
+`
+
+const Eyebrow = styled.p`
+  margin-bottom: var(--sizing-sm);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-blue);
+`
+
+const Title = styled.h1`
+  margin-bottom: var(--sizing-md);
+  font-size: 2.25rem;
+  line-height: 1.25;
+  font-weight: var(--font-weight-extra-bold);
+  color: var(--color-text);
+
+  @media (max-width: ${({ theme }) => theme.device.sm}) {
+    font-size: var(--text-lg);
+  }
+`
+
+const Lead = styled.p`
+  font-size: var(--text-md);
+  line-height: 1.8;
+  color: var(--color-text-2);
+`
+
+const Section = styled.section`
+  padding: var(--sizing-lg) 0;
+  border-top: 1px solid var(--color-divider);
+`
+
+const SectionTitle = styled.h2`
+  margin-bottom: var(--sizing-base);
+  font-size: var(--text-title);
+  line-height: 1.45;
+  font-weight: var(--font-weight-bold);
+`
+
+const Paragraph = styled.p`
+  margin-bottom: var(--sizing-base);
+  font-size: var(--text-base);
+  line-height: 1.9;
+  color: var(--color-text-2);
+`
+
+const ExternalLink = styled.a`
+  color: var(--color-blue);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+`
+
+const ActionLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 var(--padding-sm);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--border-radius-sm);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+`
+
+export default AboutPageTemplate

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -35,34 +35,20 @@ const AboutPageTemplate = () => {
           </Header>
 
           <Section>
-            <SectionTitle>운영 주체</SectionTitle>
+            <SectionTitle>잉플 소개</SectionTitle>
             <Paragraph>
-              잉플은 solaqua가 운영하는 개인 영어 학습 프로젝트입니다. 사이트의
-              목표는 한국어 사용자가 영어 표현을 검색하고, 문맥 안에서 이해하고,
-              직접 말해볼 수 있도록 짧고 반복 가능한 학습 자료를 제공하는
-              것입니다.
-            </Paragraph>
-            <Paragraph>
-              개발과 콘텐츠 관리 이력은{" "}
-              <ExternalLink href="https://github.com/engple" rel="noreferrer">
-                GitHub의 Engple 조직
-              </ExternalLink>
-              에서 확인할 수 있습니다.
+              잉플은 일상에서 바로 써볼 수 있는 영어 표현을 한국어 설명과 함께
+              모아두는 학습 공간입니다. 짧은 글 안에서 뜻, 쓰임, 예문을 빠르게
+              확인할 수 있게 정리합니다.
             </Paragraph>
           </Section>
 
           <Section>
-            <SectionTitle>콘텐츠 제작 방식</SectionTitle>
+            <SectionTitle>학습 방식</SectionTitle>
             <Paragraph>
-              각 글은 하나의 영어 표현, 패턴, 어휘, 또는 주제를 중심으로
-              구성됩니다. 한국어 설명, 영어 예문, 발음 정보, 연습 카드, 관련
-              표현을 함께 배치해 학습자가 같은 표현을 여러 상황에서 확인할 수
-              있게 합니다.
-            </Paragraph>
-            <Paragraph>
-              일부 초안 작성과 예문 후보 수집에는 자동화 도구를 사용합니다. 게시
-              전에는 표현의 자연스러움, 한국어 설명의 정확성, 내부 링크, 중복
-              여부를 점검하며, 발견한 오류는 이후 수정합니다.
+              하나의 표현을 여러 예문으로 반복해서 보고, 연습 카드로 한 번 더
+              떠올려볼 수 있도록 구성했습니다. 어색한 표현이나 잘못된 설명은
+              발견하는 대로 고쳐갑니다.
             </Paragraph>
           </Section>
 
@@ -70,15 +56,7 @@ const AboutPageTemplate = () => {
             <SectionTitle>수정과 문의</SectionTitle>
             <Paragraph>
               영어 표현은 맥락과 지역에 따라 자연스러움이 달라질 수 있습니다.
-              부정확한 번역, 어색한 예문, 깨진 링크, 저작권 또는 기타 문의가
-              있으면{" "}
-              <ExternalLink
-                href="https://github.com/engple/engple.github.io/issues"
-                rel="noreferrer"
-              >
-                GitHub Issues
-              </ExternalLink>
-              를 통해 알려주세요.
+              부정확한 번역, 어색한 예문, 깨진 링크를 발견하면 알려주세요.
             </Paragraph>
             <ActionLink to="/">최근 학습 글 보기</ActionLink>
           </Section>
@@ -147,12 +125,6 @@ const Paragraph = styled.p`
   font-size: var(--text-base);
   line-height: 1.9;
   color: var(--color-text-2);
-`
-
-const ExternalLink = styled.a`
-  color: var(--color-blue);
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
 `
 
 const ActionLink = styled(Link)`

--- a/src/templates/blogPost.tsx
+++ b/src/templates/blogPost.tsx
@@ -107,6 +107,8 @@ const BlogPost: React.FC<PageProps<DataProps, PageContext>> = ({
   const pageUrl = `${site.siteUrl}${slug}`
   const articleId = `${pageUrl}#article`
   const definedTermId = `${pageUrl}#definedterm`
+  const organizationId = `${site.siteUrl}/about/#organization`
+  const personId = `${site.siteUrl}/about/#person`
   const expression = getExpressionTerm({ category, title, faqs })
   const tocHeadings =
     faqItems.length > 0
@@ -135,16 +137,16 @@ const BlogPost: React.FC<PageProps<DataProps, PageContext>> = ({
     dateModified: lastmod || date,
     author: {
       "@type": "Person",
-      "@id": `${site.siteUrl}/#person`,
-      name: "Engple Team",
-      url: "https://github.com/engple",
+      "@id": personId,
+      name: site.author || "solaqua",
+      url: `${site.siteUrl}/about/`,
     },
     description,
     url: pageUrl,
     thumbnailUrl: `${site.siteUrl}${ogImagePath}`,
     image: `${site.siteUrl}${ogImagePath}`,
-    copyrightHolder: { "@id": `${site.siteUrl}/#organization` },
-    publisher: { "@id": `${site.siteUrl}/#organization` },
+    copyrightHolder: { "@id": organizationId },
+    publisher: { "@id": organizationId },
     isPartOf: { "@id": `${site.siteUrl}/#website` },
     mainEntityOfPage: {
       "@type": "WebPage",
@@ -218,7 +220,7 @@ const BlogPost: React.FC<PageProps<DataProps, PageContext>> = ({
       educationalRole: "student",
       audienceType: "Korean English learners",
     },
-    provider: { "@id": `${site.siteUrl}/#organization` },
+    provider: { "@id": organizationId },
   } as LearningResource
 
   const definedTermJsonLd = expression

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -146,13 +146,6 @@ export function createPracticeQuizJsonLd({
   title: string
 }) {
   const cards = getPracticeCards(html)
-  const aboutJsonLd = aboutId
-    ? {
-        "@type": "DefinedTerm",
-        "@id": aboutId,
-        name: expression || title,
-      }
-    : { "@type": "Thing", name: expression || title }
 
   if (cards.length === 0) return
 
@@ -160,7 +153,13 @@ export function createPracticeQuizJsonLd({
     "@type": "Quiz",
     "@id": id,
     name: `${title} 연습 문제`,
-    about: aboutJsonLd,
+    about: aboutId
+      ? {
+          "@type": "DefinedTerm",
+          "@id": aboutId,
+          name: expression || title,
+        }
+      : { "@type": "Thing", name: expression || title },
     educationalAlignment: {
       "@type": "AlignmentObject",
       alignmentType: "educationalSubject",

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -146,6 +146,13 @@ export function createPracticeQuizJsonLd({
   title: string
 }) {
   const cards = getPracticeCards(html)
+  const aboutJsonLd = aboutId
+    ? {
+        "@type": "DefinedTerm",
+        "@id": aboutId,
+        name: expression || title,
+      }
+    : { "@type": "Thing", name: expression || title }
 
   if (cards.length === 0) return
 
@@ -153,9 +160,7 @@ export function createPracticeQuizJsonLd({
     "@type": "Quiz",
     "@id": id,
     name: `${title} 연습 문제`,
-    about: aboutId
-      ? { "@id": aboutId }
-      : { "@type": "Thing", name: expression },
+    about: aboutJsonLd,
     educationalAlignment: {
       "@type": "AlignmentObject",
       alignmentType: "educationalSubject",

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+engple.solaqua.dev


### PR DESCRIPTION
## Why

블로그 연습 카드가 교육용 Quiz 구조화 데이터로 더 명확하게 노출되도록 보강하고, 사이트 대표 주소를 `https://engple.solaqua.dev`로 갱신합니다. 사이트를 가볍게 소개하는 About 페이지도 추가해 운영 주체와 학습 목적을 확인할 수 있게 합니다.

## Changes

- 연습 카드 기반 `Quiz` JSON-LD의 `about`에 `DefinedTerm`/`Thing` 타입과 이름을 함께 포함했습니다.
- Gatsby `siteUrl`, robots sitemap host, IndexNow host를 새 도메인 기준으로 변경했습니다.
- GitHub Pages 커스텀 도메인 유지를 위해 `static/CNAME`을 추가했습니다.
- `/about/` 페이지를 추가해 잉플 소개, 학습 방식, 수정 문의 안내를 짧게 정리했습니다.
- 상단 내비게이션에 About 링크를 노출하고 모바일 메뉴 렌더링을 복원했습니다.
- 모바일 메뉴 버튼에 `aria-expanded`와 `aria-controls`를 추가했습니다.
- 공통 JSON-LD의 `EducationalOrganization`/`Person`과 블로그 글 `author`/`publisher`를 `/about/`의 확인 가능한 엔티티로 연결했습니다.
- 중복 내부 링크 분기와 단일 사용 변수를 정리했습니다.

## Validation

- `yarn prettier --write gatsby-config.js src/layouts/layout.tsx src/components/navBar/navBar.tsx src/components/navBar/linkList.tsx src/components/navBar/menuIcon.tsx src/components/seo.tsx src/templates/blogPost.tsx src/pages/about.tsx src/utils/structuredData.ts`
- `yarn typecheck`
- 요청에 따라 `yarn build`는 실행하지 않았습니다.
